### PR TITLE
Register PopularTopics source and author-dedup filter modules

### DIFF
--- a/home-mixer/filters/mod.rs
+++ b/home-mixer/filters/mod.rs
@@ -14,6 +14,7 @@ pub mod muted_keyword_filter;
 pub mod new_user_min_engagement_filter;
 pub mod oon_nsfw_simclusters_filter;
 pub mod oon_retweet_reply_filter;
+pub mod popular_topics_author_dedup_filter;
 pub mod previously_seen_posts_backup_filter;
 pub mod previously_seen_posts_filter;
 pub mod previously_served_posts_filter;

--- a/home-mixer/sources/mod.rs
+++ b/home-mixer/sources/mod.rs
@@ -6,6 +6,7 @@ pub mod jetfuel_frame_source;
 pub mod phoenix_moe_source;
 pub mod phoenix_source;
 pub mod phoenix_topics_source;
+pub mod popular_topics_source;
 pub mod prompts_source;
 pub mod push_to_home_source;
 pub mod reverse_chron_posts_source;


### PR DESCRIPTION
## Summary
`popular_topics_author_dedup_filter.rs` and `popular_topics_source.rs` exist (with tests) but were not declared in `filters/mod.rs` / `sources/mod.rs`, so they never compiled and their tests never ran.

This PR only adds the `pub mod` lines. It does not enable `PopularTopicsSource` (its `enable()` still returns `false`) and does not wire the filter into a pipeline.

## Test plan
- [ ] `cargo test` includes PopularTopicsAuthorDedupFilter tests
- [ ] No new pipeline wiring; source remains disabled