### PR TITLE
Declare ranker Phoenix xDS retry/fallback params

### DIFF
--- a/home-mixer/params/param.rs
+++ b/home-mixer/params/param.rs
@@ -204,6 +204,18 @@ param!(
     "rust_home_mixer_phoenix_retrieval_enable_fallback",
     false
 );
+param!(
+    PhoenixXdsMaxRetries,
+    u32,
+    "rust_home_mixer_phoenix_xds_max_retries",
+    0
+);
+param!(
+    EnablePhoenixFallback,
+    bool,
+    "rust_home_mixer_phoenix_enable_fallback",
+    false
+);
 
 param!(
     PhoenixRankerNewUserInferenceClusterId,


### PR DESCRIPTION
## Summary
Ranker xDS dispatch uses feature-switch keys `rust_home_mixer_phoenix_xds_max_retries` and `rust_home_mixer_phoenix_enable_fallback`, but `param.rs` only declared the retrieval twins (`..._xds_retrieval_max_retries` / `..._retrieval_enable_fallback`). README says this file is the cron-synced production defaults.

Adds the ranker params with the same defaults as retrieval (0 / false). No pipeline behavior change beyond documenting the keys.

## Test plan
- [ ] Keys in param.rs match PredictionDispatch string keys in phoenix_candidate_pipeline.rs and phoenix_scores_pipeline.rs
