### PR TITLE
Fix Phoenix pyproject license path

### DIFF
--- a/phoenix/pyproject.toml
+++ b/phoenix/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 description = "Phoenix — X's open-source recommendation algorithm (ranking + retrieval, single-host JAX)."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { file = "LICENSE" }
+license = { text = "Apache-2.0" }
 dependencies = [
     "dm-haiku==0.0.16",
     "jax[cuda12]==0.8.1 ; sys_platform == 'linux'",

--- a/phoenix/pyproject.toml
+++ b/phoenix/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 description = "Phoenix — X's open-source recommendation algorithm (ranking + retrieval, single-host JAX)."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 dependencies = [
     "dm-haiku==0.0.16",
     "jax[cuda12]==0.8.1 ; sys_platform == 'linux'",


### PR DESCRIPTION
## Summary
`phoenix/pyproject.toml` had `license = { file = "LICENSE" }`, but there is no `phoenix/LICENSE`. The Apache-2.0 license lives at the repository root. PEP 621 `license.file` is relative to the pyproject, so packaging tools looking for `phoenix/LICENSE` fail.

This PR uses `license = { text = "Apache-2.0" }` (already in the SPDX header). README already points at the root LICENSE file.

## Test plan
- [ ] No `phoenix/LICENSE` required for `uv` / PEP 621 metadata
- [ ] SPDX header still Apache-2.0