### PR TITLE
Ignore macOS feature-switch test that needs internal YAML

### DIFF
--- a/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
+++ b/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
@@ -1010,6 +1010,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires internal xAI feature-switch YAML not shipped in this repo"]
     #[cfg(target_os = "macos")]
     fn test_feature_switches() {
         use std::env;


### PR DESCRIPTION
## Summary
`test_feature_switches` is compiled on macOS and loads `/Users/$USER/workspace/config/features/home-mixer/main/*.yml`. Those files are not in this dump, so `cargo test` on a Mac fails immediately.

This PR marks the test `#[ignore]` with a comment. No ranking changes.

## Test plan
- [ ] `cargo test` on macOS no longer fails at FeatureSwitches::load_file
- [ ] Test remains in tree for xAI laptops that have the YAML
