### PR TITLE
Fail closed when safety hydration fails

### DIFF
--- a/visibility-filtering/hydration/batch.rs
+++ b/visibility-filtering/hydration/batch.rs
@@ -114,6 +114,10 @@ impl<K: Eq + Hash, V> HydrationBatch<K, V> {
         self.results.values().filter(|r| r.is_failed()).count()
     }
 
+    pub(crate) fn is_failed(&self, key: &K) -> bool {
+        self.results.get(key).is_some_and(Hydrated::is_failed)
+    }
+
     pub(crate) fn hydrated(&self, key: &K) -> Option<&Hydrated<V>> {
         self.results.get(key)
     }

--- a/visibility-filtering/hydration/mod.rs
+++ b/visibility-filtering/hydration/mod.rs
@@ -68,6 +68,8 @@ impl CandidateFeatures {
         candidates
             .iter()
             .map(|c| {
+                let safety_hydration_failed = self.author_features.is_failed(&c.tweet_id)
+                    || self.relationships.is_failed(&c.tweet_id);
                 assemble(
                     c,
                     self.tweet_features
@@ -80,6 +82,7 @@ impl CandidateFeatures {
                         .cloned()
                         .unwrap_or_default(),
                     self.relationships.get_or_default(&c.tweet_id),
+                    safety_hydration_failed,
                     self.exclusive_content
                         .get(&c.tweet_id)
                         .cloned()
@@ -385,6 +388,32 @@ mod tests {
         assert_eq!(c.tweet_features.core.text, "two");
         assert!(c.author_features.is_suspended);
         assert!(c.relationship.viewer_follows_author);
+    }
+
+    #[test]
+    fn assemble_marks_failed_safety_hydration_without_dropping_candidate() {
+        let candidate = resolve_candidate(&raw(1, Some(100)), &HashMap::new()).unwrap();
+        let results = CandidateFeatures {
+            tweet_features: HashMap::new(),
+            author_features: TweetHydrationBatch::from_results(
+                [TweetId(1)],
+                HashMap::from([(TweetId(1), Err::<Option<AuthorFeatures>, _>("author unavailable"))]),
+            ),
+            safety_labels: HashMap::new(),
+            relationships: TweetHydrationBatch::from_results(
+                [TweetId(1)],
+                HashMap::from([(
+                    TweetId(1),
+                    Ok::<_, &str>(Some(ViewerAuthorRelationship::default())),
+                )]),
+            ),
+            exclusive_content: HashMap::new(),
+        };
+
+        let assembled = results.assemble(&[candidate]);
+
+        assert_eq!(assembled.len(), 1);
+        assert!(assembled[0].safety_hydration_failed);
     }
 
     fn raw(tweet_id: u64, request_author_id: Option<u64>) -> RawCandidate {

--- a/visibility-filtering/models/mod.rs
+++ b/visibility-filtering/models/mod.rs
@@ -71,6 +71,8 @@ pub struct HydratedTweetCandidate {
     pub author_features: AuthorFeatures,
     pub safety_labels: SafetyLabelMap,
     pub relationship: ViewerAuthorRelationship,
+    /// True when safety-critical author or social-graph hydration failed.
+    pub safety_hydration_failed: bool,
     pub exclusive_content: Option<ExclusiveContentFeatures>,
 }
 
@@ -143,6 +145,7 @@ pub fn assemble(
     author_features: AuthorFeatures,
     safety_labels: SafetyLabelMap,
     relationship: ViewerAuthorRelationship,
+    safety_hydration_failed: bool,
     exclusive_content: Option<ExclusiveContentFeatures>,
 ) -> HydratedTweetCandidate {
     HydratedTweetCandidate {
@@ -152,6 +155,7 @@ pub fn assemble(
         author_features,
         safety_labels,
         relationship,
+        safety_hydration_failed,
         exclusive_content,
     }
 }

--- a/visibility-filtering/rules/registry.rs
+++ b/visibility-filtering/rules/registry.rs
@@ -86,6 +86,22 @@ impl Default for Policies {
     }
 }
 
+struct SafetyHydrationFailureDropRule;
+
+impl Rule for SafetyHydrationFailureDropRule {
+    fn name(&self) -> &'static str {
+        "SafetyHydrationFailureDropRule"
+    }
+
+    fn evaluate(&self, context: &RuleContext<'_>) -> VfAction {
+        if context.candidate().safety_hydration_failed {
+            VfAction::Drop(FilteredReason::UnspecifiedReason)
+        } else {
+            VfAction::Allow
+        }
+    }
+}
+
 struct FilterAllRule;
 
 impl Rule for FilterAllRule {
@@ -100,6 +116,7 @@ impl Rule for FilterAllRule {
 
 fn base_home_rules() -> Vec<Box<dyn Rule>> {
     vec![
+        Box::new(SafetyHydrationFailureDropRule),
         Box::new(author::SUSPENDED_AUTHOR_DROP),
         Box::new(author::DEACTIVATED_AUTHOR_DROP),
         Box::new(author::ERASED_AUTHOR_DROP),
@@ -192,6 +209,30 @@ mod tests {
                 SafetyLevel::FilterAll | SafetyLevel::TimelineHome => VfAction::Allow,
             }
         }
+    }
+
+    #[test]
+    fn failed_safety_hydration_fails_closed_on_both_home_surfaces() {
+        let policies = Policies::new();
+        let viewer = ViewerFeatures::default();
+        let mut failed = HydratedTweetCandidate::default();
+        failed.safety_hydration_failed = true;
+
+        for level in [SafetyLevel::TimelineHome, SafetyLevel::TimelineHomeRecommendations] {
+            let verdict = policies.evaluate(level, &viewer, &failed);
+            assert!(matches!(verdict.action, VfAction::Drop(_)));
+            assert_eq!(verdict.decided_by, Some("SafetyHydrationFailureDropRule"));
+        }
+    }
+
+    #[test]
+    fn successful_safety_hydration_remains_eligible_for_normal_rules() {
+        let policies = Policies::new();
+        let viewer = ViewerFeatures::default();
+        let candidate = HydratedTweetCandidate::default();
+
+        let verdict = policies.evaluate(SafetyLevel::TimelineHome, &viewer, &candidate);
+        assert!(matches!(verdict.action, VfAction::Allow));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The visibility-filtering hydration layer converts author and viewer-relationship backend failures into default or empty metadata. Downstream rules can then evaluate the candidate as ordinary content and return `Allow`, even though safety-critical metadata was unavailable.

## Fix

- Track failed author and social-graph hydration per candidate.
- Preserve the candidate while marking safety-critical hydration failure.
- Add a first-position visibility rule that drops marked candidates before content-specific rules can allow or interstitial them.

## Tests

- Add hydration assembly coverage for failed author hydration.
- Add policy coverage proving failed hydration drops on both home surfaces.
- Add coverage proving healthy candidates remain eligible.
- `git diff --check` passes.

The repository checkout does not expose a Cargo manifest for `visibility-filtering`, and the environment lacks `cargo`, `rustc`, and `rustfmt`, so native Rust tests and formatting could not be run locally. Source-level call-site and struct-literal audits were completed.