### PR TITLE
Fix muted authors resurfacing through retweets

### DIFF
--- a/home-mixer/filters/author_socialgraph_filter.rs
+++ b/home-mixer/filters/author_socialgraph_filter.rs
@@ -41,6 +41,10 @@ impl Filter<ScoredPostsQuery, PostCandidate> for AuthorSocialgraphFilter {
                 .retweeted_user_id
                 .map(|uid| viewer_blocked_user_ids.contains(&(uid as i64)))
                 .unwrap_or(false);
+            let viewer_mutes_retweeted_user = candidate
+                .retweeted_user_id
+                .map(|uid| viewer_muted_user_ids.contains(&(uid as i64)))
+                .unwrap_or(false);
 
             if muted
                 || blocked
@@ -48,6 +52,7 @@ impl Filter<ScoredPostsQuery, PostCandidate> for AuthorSocialgraphFilter {
                 || quoted_author_blocks_viewer
                 || viewer_blocks_quoted_author
                 || viewer_blocks_retweeted_user
+                || viewer_mutes_retweeted_user
             {
                 removed.push(candidate);
             } else {
@@ -282,6 +287,44 @@ mod tests {
 
         assert_eq!(result.kept.len(), 0);
         assert_eq!(result.removed.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_muted_retweeted_author_is_removed() {
+        let filter = AuthorSocialgraphFilter;
+        let user_features = UserFeatures {
+            muted_user_ids: vec![900],
+            ..Default::default()
+        };
+        let query = make_query_with_features(user_features);
+
+        let mut retweet = make_candidate(1, 100);
+        retweet.retweeted_tweet_id = Some(2);
+        retweet.retweeted_user_id = Some(900);
+
+        let candidates = vec![retweet, make_candidate(3, 300)];
+        let result = filter.filter(&query, candidates);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 3);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].retweeted_user_id, Some(900));
+    }
+
+    #[tokio::test]
+    async fn test_unmuted_retweeted_author_is_kept() {
+        let filter = AuthorSocialgraphFilter;
+        let query = make_query_with_features(UserFeatures::default());
+
+        let mut retweet = make_candidate(1, 100);
+        retweet.retweeted_tweet_id = Some(2);
+        retweet.retweeted_user_id = Some(900);
+
+        let result = filter.filter(&query, vec![retweet]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].retweeted_user_id, Some(900));
+        assert!(result.removed.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`AuthorSocialgraphFilter` checked the viewer’s block list for `retweeted_user_id` but did not apply the viewer’s mute list. As a result, a post from a muted original author could resurface when another account retweeted it.

## Fix

Apply `viewer_muted_user_ids` to `candidate.retweeted_user_id` and remove the candidate when the original retweeted author is muted.

## Tests

Added regression coverage for both a muted retweeted author (removed) and an unmuted retweeted author (kept).

`git diff --check` passes. The full Rust test suite could not be run in the local environment because this checkout does not expose a `home-mixer` Cargo manifest and the environment lacks `cargo`, `rustc`, and `rustfmt`.