### PR TITLE
Expose restriction scope in Under the Hood reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,13 @@ The focus of the repository is transparency into the code that affects post visi
 
 We're piloting a new transparency tool that lets people see aggregate statistics about the visibility-impacting labels on their account and posts. Paired with the code in this repository, we believe this gives people valuable insight into the visibility of their posts.
 
+The report describes a completed historical month rather than a live account-status check. It
+includes the Home surfaces affected by each reported label, whether the checked-in Home policy can
+affect follower delivery, post-label removals observed during the configured observation window,
+and the first and last days on which an account label was observed. Exact application, expiry, and
+review timestamps, model/source provenance, and appeal availability are not present in the monthly
+aggregate and are therefore reported as unavailable rather than inferred.
+
 The tool is [available here](https://x.com/i/under_the_hood) — we'll be shaping it based on your feedback and expanding availability over time. The jobs and serving code that build the report are in [`under-the-hood/`](under-the-hood/).
 
 ---

--- a/under-the-hood/strato/columns/underTheHoodReport.User.strato
+++ b/under-the-hood/strato/columns/underTheHoodReport.User.strato
@@ -35,6 +35,15 @@ val englishMonthNames = Seq(
 val reportNotes =
   "You can learn more about instances when a post’s reach may be limited by reading our open-source code at https://github.com/xai-org/x-algorithm and the guide at https://help.x.com/rules-and-policies/x-reach-limited. Learn more about account and post-level enforcement options here https://help.x.com/rules-and-policies/enforcement-options. " +
     "This report is provided on a best-effort basis — the code that generates it is open-source: https://github.com/xai-org/x-algorithm/tree/main/under-the-hood"
+val restrictionDataFreshness = "HISTORICAL_MONTHLY_SNAPSHOT"
+val unavailableRestrictionFields = Seq(
+  "appliedAt",
+  "expiresAt",
+  "nextReviewAt",
+  "source",
+  "modelVersion",
+  "appealAvailability",
+)
 
 val utcYyyyMm = TimeFormat.apply("yyyyMM").withZone("UTC")
 val utcYyyyMmDd = TimeFormat.apply("yyyy-MM-dd").withZone("UTC")
@@ -150,6 +159,17 @@ def sumCarried(days: Option[Seq[UthDayCarriedRemoved]]): Long =
     acc + d.carried.getOrElse(0L)
   }
 
+def sumRemoved(days: Option[Seq[UthDayCarriedRemoved]]): Long =
+  days.getOrElse(Seq.empty).foldLeft(0L) { (acc, d) =>
+    acc + d.removed.getOrElse(0L)
+  }
+
+def dateForDayOfMonth(monthBucket: Int, dayOfMonth: Int): String = {
+  val year = monthBucket / 100
+  val month = monthBucket % 100
+  year.toString + "-" + pad2(month) + "-" + pad2(dayOfMonth)
+}
+
 def sumDayCounts(days: Option[Seq[UthDayCount]]): Long =
   days.getOrElse(Seq.empty).foldLeft(0L) { (acc, d) =>
     acc + d.count.getOrElse(0L)
@@ -190,11 +210,19 @@ def buildReportJson(
     .flatMap { agg =>
       agg.label.filter(underTheHoodLabels.isPostLabel).map { raw =>
         val posts = sumCarried(agg.days)
+        val removed = sumRemoved(agg.days)
+        val stillLabeled = if (posts >= removed) { posts - removed } else { 0L }
         {
+          scope = "POST",
           label = underTheHoodLabels.postLabelName(raw),
           about = underTheHoodLabels.postLabelAbout(raw),
           effect = underTheHoodLabels.postLabelEffect(raw),
+          recommendationAffectedSurfaces =
+            underTheHoodLabels.postLabelRecommendationAffectedSurfaces(raw),
+          followerDeliveryAffected = underTheHoodLabels.postLabelAffectsFollowerDelivery(raw),
           posts = posts,
+          removedWithinObservationWindow = removed,
+          stillLabeledAtObservationEnd = stillLabeled,
           totalPostsInMonth = postCount,
           percentageOfPosts = formatPercentage(posts, postCount),
         }
@@ -205,23 +233,48 @@ def buildReportJson(
     .getOrElse(Seq.empty)
     .flatMap { agg =>
       agg.label.filter(underTheHoodLabels.isAccountLabel).map { raw =>
-        val days = agg.activeDays.map { d => d.size.toLong }.getOrElse(0L)
+        val activeDays = agg.activeDays.getOrElse(Seq.empty).distinct.sorted
+        val days = activeDays.size.toLong
+        val activeAtPeriodEnd = activeDays.lastOption.exists { day =>
+          day == calendarDaysInMonthBucket(monthBucket)
+        }
         {
+          scope = "ACCOUNT",
           label = underTheHoodLabels.accountLabelName(raw),
           about = underTheHoodLabels.accountLabelAbout(raw),
           effect = underTheHoodLabels.accountLabelEffect(raw),
+          recommendationAffectedSurfaces =
+            underTheHoodLabels.accountLabelRecommendationAffectedSurfaces(raw),
+          followerDeliveryAffected =
+            underTheHoodLabels.accountLabelAffectsFollowerDelivery(raw),
           days = days,
           daysInPeriod = periodDays,
           percentageOfDays = formatPercentage(days, periodDays.toLong),
+          firstObservedDate = activeDays.headOption.map { day =>
+            dateForDayOfMonth(monthBucket, day)
+          },
+          lastObservedDate = activeDays.lastOption.map { day =>
+            dateForDayOfMonth(monthBucket, day)
+          },
+          activeAtPeriodEnd = activeAtPeriodEnd,
         }
       }
     }
+
+  val restrictionData = {
+    freshness = restrictionDataFreshness,
+    accountStatusAsOf = period.endDate,
+    postStatusBasis = "AUTHORED_POST_OBSERVATION_WINDOW",
+    postObservationDays = userMonth.daysIncluded.flatMap { d => d.postObservationDays },
+    unavailableFields = unavailableRestrictionFields,
+  }
 
   if (postLabels.isEmpty && accountLabels.isEmpty) {
     {
       notes = reportNotes,
       period = period,
       generatedAt = formatGeneratedAtIso(generatedAtMs),
+      restrictionData = restrictionData,
       postCount = postCount,
       postLabels = postLabels,
       accountLabels = accountLabels,
@@ -233,6 +286,7 @@ def buildReportJson(
       notes = reportNotes,
       period = period,
       generatedAt = formatGeneratedAtIso(generatedAtMs),
+      restrictionData = restrictionData,
       postCount = postCount,
       postLabels = postLabels,
       accountLabels = accountLabels,
@@ -243,6 +297,7 @@ def buildReportJson(
       notes = reportNotes,
       period = period,
       generatedAt = formatGeneratedAtIso(generatedAtMs),
+      restrictionData = restrictionData,
       postCount = postCount,
       postLabels = postLabels,
       accountLabels = accountLabels,
@@ -253,6 +308,7 @@ def buildReportJson(
       notes = reportNotes,
       period = period,
       generatedAt = formatGeneratedAtIso(generatedAtMs),
+      restrictionData = restrictionData,
       postCount = postCount,
       postLabels = postLabels,
       accountLabels = accountLabels,

--- a/under-the-hood/strato/lib/underTheHoodLabels.strato
+++ b/under-the-hood/strato/lib/underTheHoodLabels.strato
@@ -175,6 +175,23 @@ val accountLabels = Map(
   },
 )
 
+// These are public product-surface names, not internal rule or policy identifiers. Keep this
+// mapping aligned with visibility-filtering/rules/registry.rs. Labels outside the base Home
+// policy affect recommendation eligibility only.
+val timelineHomeSurface = "TIMELINE_HOME"
+val timelineHomeRecommendationsSurface = "TIMELINE_HOME_RECOMMENDATIONS"
+
+val postLabelsAffectingTimelineHome = Set(
+  "SPAM",
+  "PDNA",
+  "BOUNCE",
+  "FOR_EMERGENCY_USE_ONLY",
+  "FOSNR_ABUSE",
+  "FOSNR_HATEFUL_CONDUCT",
+  "FOSNR_VIOLENT_SPEECH",
+  "FOSNR_CIVIC_INTEGRITY",
+)
+
 val underscore = Regex.compile("_")
 
 def normalizeLabel(code: String): String =
@@ -260,6 +277,28 @@ def accountLabelEffect(code: String): String =
     case None => ""
   }
 
+def postLabelRecommendationAffectedSurfaces(code: String): Seq[String] =
+  resolvePostKey(code) match {
+    case Some(k) if postLabelsAffectingTimelineHome.contains(k) =>
+      Seq(timelineHomeSurface, timelineHomeRecommendationsSurface)
+    case Some(_) => Seq(timelineHomeRecommendationsSurface)
+    case None => Seq.empty
+  }
+
+def accountLabelRecommendationAffectedSurfaces(code: String): Seq[String] =
+  resolveAccountKey(code) match {
+    case Some(_) => Seq(timelineHomeRecommendationsSurface)
+    case None => Seq.empty
+  }
+
+def postLabelAffectsFollowerDelivery(code: String): Boolean =
+  resolvePostKey(code).exists { k => postLabelsAffectingTimelineHome.contains(k) }
+
+// Account labels in the public allowlist are applied by the recommendation-only policy in the
+// checked-in visibility registry. This describes Home delivery only; it makes no claim about
+// search, notifications, or other products that are not evaluated by that registry.
+def accountLabelAffectsFollowerDelivery(code: String): Boolean = false
+
 Library({
   export = {
     postLabels = postLabels,
@@ -276,6 +315,10 @@ Library({
     accountLabelAbout = accountLabelAbout,
     postLabelEffect = postLabelEffect,
     accountLabelEffect = accountLabelEffect,
+    postLabelRecommendationAffectedSurfaces = postLabelRecommendationAffectedSurfaces,
+    accountLabelRecommendationAffectedSurfaces = accountLabelRecommendationAffectedSurfaces,
+    postLabelAffectsFollowerDelivery = postLabelAffectsFollowerDelivery,
+    accountLabelAffectsFollowerDelivery = accountLabelAffectsFollowerDelivery,
   },
   description = PlainText(
     "Under the Hood public label allowlists (canonical name -> about/effect) and helpers."


### PR DESCRIPTION
## Summary
- expose whether a reported restriction is post- or account-scoped
- identify the checked-in Home surfaces affected and whether follower delivery can be affected
- report observed post-label removals and account-label first/last observed dates plus month-end activity
- add explicit historical-snapshot freshness and enumerate metadata unavailable from the monthly aggregate

## Why
The existing report gives opaque monthly counts. This makes its actual observation window and delivery effects inspectable without exposing internal actor/rule identifiers or inventing application, expiry, model, review, source, or appeal metadata that is not present in the aggregate.

## Verification
- `git diff --check`
- focused static contract-field check for all new report fields and label helpers

The public snapshot provides no Under-the-Hood build/test target and no local Strato typechecker, so Strato compilation could not be run here. This remains a historical report, not a live restriction-status endpoint; the JSON states that explicitly.