### PR TITLE
Register BroadcastLivenessHydrator module

### DIFF
--- a/home-mixer/candidate_hydrators/mod.rs
+++ b/home-mixer/candidate_hydrators/mod.rs
@@ -1,6 +1,7 @@
 pub mod ads_brand_safety_vf_hydrator;
 pub mod bidirectional_follow_hydrator;
 pub mod blocked_by_hydrator;
+pub mod broadcast_liveness_hydrator;
 pub mod conversation_gap_ancestor_hydrator;
 pub mod core_data_candidate_hydrator;
 pub mod engagement_counts_hydrator;


### PR DESCRIPTION
## Summary
`broadcast_liveness_hydrator.rs` exists (with tests) and `docs/BIDIRECTIONAL_BOOST_CHANGE.md` shows the `pub mod` / use lines, but `candidate_hydrators/mod.rs` never declared the module, so the hydrator and its tests never compiled.

This PR only adds the `pub mod` line in alpha order. It does not insert the hydrator into a pipeline.

## Test plan
- [ ] `pub mod broadcast_liveness_hydrator` is in `home-mixer/candidate_hydrators/mod.rs`
- [ ] No new pipeline wiring
