### PR TITLE
Remove credibility-based enforcement bypasses

### DIFF
--- a/abuse-enforcement-service/README.md
+++ b/abuse-enforcement-service/README.md
@@ -1,0 +1,19 @@
+# Abuse enforcement rules
+
+The baked-in user and post rule pipelines are evaluated from top to bottom. Explicit
+allowlists and missing-entity checks remain the only identity-level guardrails that
+run before abuse signals. Follower count, PageRank, and user-credibility scores must
+not be used as blanket skip conditions: those signals can contribute evidence to a
+calibrated decision, but they do not make an account or author immune from otherwise
+applicable enforcement.
+
+The YAML files in `service-lib/rules/` are fallback copies mirrored from GrowthBook.
+A valid GrowthBook override takes precedence over these files, and an invalid override
+falls back to the last known good pipeline. Deploying a rule change therefore requires
+updating and validating the corresponding GrowthBook configuration as well as the
+checked-in fallback; changing only this repository may leave production behavior
+unchanged.
+
+`skip_author_credibility_prechecks` remains part of the score-to-CEL contract for
+backward compatibility with dynamic rules that explicitly opt into that behavior. It
+does not restore a follower-count or credibility-based bypass in the baked-in rules.

--- a/abuse-enforcement-service/service-lib/rules/enforcement_post.yaml
+++ b/abuse-enforcement-service/service-lib/rules/enforcement_post.yaml
@@ -1,4 +1,6 @@
 # mirrored from GrowthBook dynamic config; last sync 2026-08-06T16:20:00Z
+# Production can override this file through GrowthBook. Keep the dynamic rules in sync:
+# author credibility and follower-count signals must not bypass abuse enforcement.
 
 for_entity: post
 
@@ -20,21 +22,6 @@ rules:
     then:
       kind: skip
       reason: user_not_found
-
-  - id: high_follower_count
-    # Prod uses a different follower count floor; this is a mock value to reduce gaming.
-    when: cred.follower_count >= 12.34 && !score.skip_author_credibility_prechecks
-    then:
-      kind: skip
-      reason: high_follower_count
-
-  - id: pagerank_skipped
-    when: >
-      (cred.is_high || cred.score >= 50.0)
-      && !score.skip_author_credibility_prechecks
-    then:
-      kind: skip
-      reason: pagerank_skipped
 
   - id: act_add_llm_slop_post_label
     when: '"llm_slop_post" in score.labels'

--- a/abuse-enforcement-service/service-lib/rules/enforcement_user.yaml
+++ b/abuse-enforcement-service/service-lib/rules/enforcement_user.yaml
@@ -1,4 +1,6 @@
 # mirrored from GrowthBook dynamic config; last sync 2026-08-12T16:22:21Z
+# Production can override this file through GrowthBook. Keep the dynamic rules in sync:
+# credibility and follower-count signals must not bypass abuse enforcement.
 
 for_entity: user
 
@@ -14,22 +16,6 @@ rules:
     then:
       kind: skip
       reason: user_not_found
-
-  - id: high_follower_count
-    # Prod uses a different follower count floor; this is a mock value to reduce gaming.
-    when: cred.follower_count >= 12.34
-    then:
-      kind: skip
-      reason: high_follower_count
-
-  - id: pagerank_skipped
-    when: >
-      cred.is_high
-      || cred.score >= 50.0
-    then:
-      kind: skip
-      reason: pagerank_skipped
-
 
   - id: anchor_campaign_suspend
     when: '"anchor_campaign_suspend" in score.labels'

--- a/abuse-enforcement-service/service-lib/src/fixtures/mock_rules_post.yaml
+++ b/abuse-enforcement-service/service-lib/src/fixtures/mock_rules_post.yaml
@@ -3,6 +3,8 @@ rules:
   - id: post_allowlisted
     when: post_allowlist.is_allowlisted || user_allowlist.is_allowlisted
     then: { kind: skip, reason: post_allowlisted }
+  # Parser fixture only: retain a legacy credibility expression to verify that
+  # dynamic rules using the existing CEL contract remain compatible.
   - id: author_cred_skip
     when: cred.is_high
     then: { kind: skip, reason: author_cred_skip }

--- a/abuse-enforcement-service/service-lib/src/fixtures/mock_rules_user.yaml
+++ b/abuse-enforcement-service/service-lib/src/fixtures/mock_rules_user.yaml
@@ -6,6 +6,8 @@ rules:
   - id: not_present
     when: "!user.present"
     then: { kind: skip, reason: not_present }
+  # Parser fixture only: retain a legacy credibility expression to verify that
+  # dynamic rules using the existing CEL contract remain compatible.
   - id: cred_skip
     when: cred.is_high || cred.follower_count >= 1234 || cred.score >= 7.5
     then: { kind: skip, reason: cred_skip }

--- a/abuse-enforcement-service/service-lib/src/rules.rs
+++ b/abuse-enforcement-service/service-lib/src/rules.rs
@@ -639,29 +639,28 @@ mod tests {
         assert_eq!(post.source, RuleSource::Static);
         assert!(!user.rule_ids.is_empty(), "user pipeline empty");
         assert!(!post.rule_ids.is_empty(), "post pipeline empty");
-        for id in [
-            "user_in_allowlist",
-            "user_not_found",
-            "high_follower_count",
-            "pagerank_skipped",
-        ] {
+        for id in ["user_in_allowlist", "user_not_found"] {
             assert!(
                 user.rule_ids.iter().any(|r| r == id),
                 "user missing guardrail {id:?}; got {:?}",
                 user.rule_ids
             );
         }
-        for id in [
-            "post_in_allowlist",
-            "user_in_allowlist",
-            "user_not_found",
-            "high_follower_count",
-            "pagerank_skipped",
-        ] {
+        for id in ["post_in_allowlist", "user_in_allowlist", "user_not_found"] {
             assert!(
                 post.rule_ids.iter().any(|r| r == id),
                 "post missing guardrail {id:?}; got {:?}",
                 post.rule_ids
+            );
+        }
+        for removed in ["high_follower_count", "pagerank_skipped"] {
+            assert!(
+                !user.rule_ids.iter().any(|r| r == removed),
+                "user credibility bypass {removed:?} must not be present"
+            );
+            assert!(
+                !post.rule_ids.iter().any(|r| r == removed),
+                "post credibility bypass {removed:?} must not be present"
             );
         }
     }
@@ -764,6 +763,91 @@ mod tests {
         let rules = RulesCache::new().resolve(EntityType::User, None);
         let mut f = base_facts();
         f.user_allowlist_mut().is_allowlisted = true;
+        f.score.labels = vec!["anchor_campaign_suspend".into()];
+        f.cred_mut().is_high = Some(true);
+        assert_eq!(
+            decide_with(&rules, &f).unwrap(),
+            Decision::Skip("user_in_allowlist".into())
+        );
+    }
+
+    #[test]
+    fn baked_in_missing_user_still_precedes_enforcement() {
+        let user_rules = RulesCache::new().resolve(EntityType::User, None);
+        let mut user = base_facts();
+        user.user_mut().present = false;
+        user.score.labels = vec!["anchor_campaign_suspend".into()];
+        assert_eq!(
+            decide_with(&user_rules, &user).unwrap(),
+            Decision::Skip("user_not_found".into())
+        );
+
+        let post_rules = RulesCache::new().resolve(EntityType::Post, None);
+        let mut missing_author = safe_author();
+        missing_author.user.present = false;
+        let post = post_facts(missing_author, vec!["gibberish_post".into()]);
+        assert_eq!(
+            decide_with(&post_rules, &post).unwrap(),
+            Decision::Skip("user_not_found".into())
+        );
+    }
+
+    #[test]
+    fn baked_in_user_credibility_does_not_bypass_enforcement() {
+        let rules = RulesCache::new().resolve(EntityType::User, None);
+        let mut f = base_facts();
+        f.score.labels = vec!["anchor_campaign_suspend".into()];
+        f.cred_mut().is_high = Some(true);
+        f.cred_mut().score = Some(100.0);
+        f.cred_mut().follower_count = Some(10_000_000);
+
+        assert_eq!(
+            decide_with(&rules, &f).unwrap(),
+            Decision::Act(vec![ActionSpec::SuspendUser {
+                perm: false,
+                policy: "PlatformManipulation".into(),
+            }])
+        );
+    }
+
+    #[test]
+    fn baked_in_post_credibility_does_not_bypass_enforcement() {
+        let rules = RulesCache::new().resolve(EntityType::Post, None);
+        for skip_prechecks in [false, true] {
+            let mut author = safe_author();
+            author.cred.is_high = Some(true);
+            author.cred.score = Some(100.0);
+            author.cred.follower_count = Some(10_000_000);
+            let mut f = post_facts(author, vec!["gibberish_post".into()]);
+            f.score.skip_author_credibility_prechecks = skip_prechecks;
+
+            assert_eq!(
+                decide_with(&rules, &f).unwrap(),
+                Decision::Act(vec![ActionSpec::AddPostLabelsV2 {
+                    labels: vec!["SpamHighRecall".into()],
+                    ttl_msec: Some(2_592_000_000),
+                }])
+            );
+        }
+    }
+
+    #[test]
+    fn baked_in_post_allowlists_still_precede_enforcement() {
+        let rules = RulesCache::new().resolve(EntityType::Post, None);
+        let mut f = with_post_allowlisted(post_facts(
+            safe_author(),
+            vec!["gibberish_post".into()],
+        ));
+        f.cred_mut().is_high = Some(true);
+
+        assert_eq!(
+            decide_with(&rules, &f).unwrap(),
+            Decision::Skip("post_in_allowlist".into())
+        );
+
+        let mut allowlisted_author = safe_author();
+        allowlisted_author.allowlist.is_allowlisted = true;
+        let f = post_facts(allowlisted_author, vec!["gibberish_post".into()]);
         assert_eq!(
             decide_with(&rules, &f).unwrap(),
             Decision::Skip("user_in_allowlist".into())


### PR DESCRIPTION
## Summary
- remove follower-count and PageRank/UserCred early exits from baked user and post abuse-enforcement rules
- preserve explicit allowlist and missing-entity guardrails
- preserve the legacy CEL field for dynamic-rule compatibility without using it as a baked credibility bypass
- add focused pipeline tests and document ordered semantics plus GrowthBook synchronization requirements

## Why
Credibility and popularity can be evidence inputs, but should not make an account or author categorically immune from otherwise applicable abuse enforcement.

## Verification
- Rust source parsed with `rustfmt --edition 2024`
- focused rule invariant checks
- `git diff --check` / `git show --check`

The public abuse-service snapshot omits its Cargo manifest, so the Rust tests cannot be executed here. Production GrowthBook rules must be updated with the same removals or they may continue overriding the baked fallback.