### PR TITLE
Make UserCred teleport prior verification-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ These produce the scores and labels that Visibility Filtering reads.
 | [`clip/`](clip/)                           | Trains the image and text embedding model whose media embeddings the classifiers above take as input.                                                                                 |
 | [`agatha/`](agatha/)                       | Offline batch jobs that label an account from how others respond to its posts: blocks, reports and spam reports relative to favorites, plus spam-suspension and adult-content labels. |
 | [`bdsm/`](bdsm/)                           | Reads the sequence of actions an account takes over time to identify signs of inauthentic or abusive behavior.                                                                        |
-| [`user-cred-v2/`](user-cred-v2/)           | Runs PageRank over the follow graph and engagement edges, and turns the resulting mass into a per-account score.                                                                      |
+| [`user-cred-v2/`](user-cred-v2/)           | Runs PageRank over the follow graph and engagement edges, using a verification-neutral uniform teleport prior across all eligible non-near-zero accounts, and turns the resulting mass into a per-account score.                                    |
 | [`adult-content/`](adult-content/)         | Trains and calibrates a classifier for adult media.                                                                                                                                   |
 | [`pnsfwmedia/`](pnsfwmedia/)               | An adult-media classifier that combines CLIP media embeddings with account-level scores, including the calibrated score from `agatha`.                                                |
 

--- a/user-cred-v2/UserCredV2App.scala
+++ b/user-cred-v2/UserCredV2App.scala
@@ -56,11 +56,6 @@ object UserCredV2App extends Logging {
       "deactivated",
       "erased",
       "id",
-      "is_blue_verified",
-      "is_gold_verified",
-      "is_gray_verified",
-      "is_verified_organization",
-      "is_verified_organization_affiliate",
       "restricted",
       "suspended",
       "user_state",
@@ -170,19 +165,27 @@ object UserCredV2App extends Logging {
       rawEngagementWeights.toTypedPipe.map { case (id, weight) => UserMass(id, weight) }
     )
 
-    val normalizedUniform = getNormalizedUserMassPipe(
-      validUserInfoPipe.filter(u => !u.isNearZero && u.isPremium).map(u => UserMass(u.id, 1.0))
+    val neutralPriorEligibleUsers = Stat("neutral_teleport_prior_eligible_users")
+    val neutralPriorNearZeroExcludedUsers =
+      Stat("neutral_teleport_prior_near_zero_excluded_users")
+    val normalizedNeutralPrior = getNormalizedUserMassPipe(
+      validUserInfoPipe.flatMap { user =>
+        val mass = neutralTeleportMass(user)
+        if (mass.isDefined) neutralPriorEligibleUsers.inc()
+        else neutralPriorNearZeroExcludedUsers.inc()
+        mass
+      }
     )
 
-    val blended = normalizedUniform
+    val blended = normalizedNeutralPrior
       .map(u => (u.id, u.mass))
       .group
       .outerJoin(normalizedEngagement.groupBy(_.id).mapValues(_.mass))
       .map {
-        case (id, (Some(uniform), Some(engagement))) =>
-          UserMass(id, (1.0 - beta) * uniform + beta * engagement)
-        case (id, (Some(uniform), None)) =>
-          UserMass(id, (1.0 - beta) * uniform)
+        case (id, (Some(neutralPrior), Some(engagement))) =>
+          UserMass(id, (1.0 - beta) * neutralPrior + beta * engagement)
+        case (id, (Some(neutralPrior), None)) =>
+          UserMass(id, (1.0 - beta) * neutralPrior)
         case (id, (None, Some(engagement))) =>
           UserMass(id, beta * engagement)
         case (id, (None, None)) =>
@@ -190,6 +193,14 @@ object UserCredV2App extends Logging {
       }
 
     getNormalizedUserMassPipe(blended)
+  }
+
+  /**
+   * The uniform component of the teleport prior covers every graph-eligible user equally.
+   * Verification and subscription state are deliberately not inputs to this decision.
+   */
+  private[user_cred_v2] def neutralTeleportMass(user: ValidUserInfo): Option[UserMass] = {
+    if (user.isNearZero) None else Some(UserMass(user.id, 1.0))
   }
 
   private[user_cred_v2] def pageRankMain(
@@ -272,9 +283,12 @@ object UserCredV2App extends Logging {
   private[user_cred_v2] def getNormalizedUserMassPipe(
     userMassPipe: TypedPipe[UserMass]
   ): TypedPipe[UserMass] = {
-    val massSum = userMassPipe.map(_.mass).sum
+    val safeMassPipe = userMassPipe.map { userMass =>
+      userMass.copy(mass = sanitizeMass(userMass.mass))
+    }
+    val massSum = safeMassPipe.map(_.mass).sum
 
-    userMassPipe
+    safeMassPipe
       .cross(massSum)
       .map {
         case (UserMass(id, mass), totalMass) if totalMass > 0 =>
@@ -282,6 +296,10 @@ object UserCredV2App extends Logging {
         case (UserMass(id, _), _) =>
           UserMass(id, 0.0)
       }
+  }
+
+  private[user_cred_v2] def sanitizeMass(mass: Double): Double = {
+    if (java.lang.Double.isFinite(mass) && mass > 0.0) mass else 0.0
   }
 
   private[user_cred_v2] def getPageRankGraph(

--- a/user-cred-v2/UserCredV2AppTest.scala
+++ b/user-cred-v2/UserCredV2AppTest.scala
@@ -1,0 +1,37 @@
+package com.twitter.health.platform_manipulation.user_cred_v2
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class UserCredV2AppTest extends AnyWordSpec with Matchers {
+  "neutralTeleportMass" should {
+    "include every eligible non-near-zero user with equal raw mass" in {
+      UserCredV2App.neutralTeleportMass(ValidUserInfo(id = 1L, isNearZero = false)) shouldBe
+        Some(UserMass(id = 1L, mass = 1.0))
+      UserCredV2App.neutralTeleportMass(ValidUserInfo(id = 2L, isNearZero = false)) shouldBe
+        Some(UserMass(id = 2L, mass = 1.0))
+    }
+
+    "exclude near-zero users" in {
+      UserCredV2App.neutralTeleportMass(ValidUserInfo(id = 3L, isNearZero = true)) shouldBe None
+    }
+  }
+
+  "sanitizeMass" should {
+    "preserve finite positive engagement-derived mass" in {
+      UserCredV2App.sanitizeMass(0.25) shouldBe 0.25
+    }
+
+    "zero invalid mass before normalization" in {
+      Seq(
+        0.0,
+        -1.0,
+        Double.NaN,
+        Double.PositiveInfinity,
+        Double.NegativeInfinity,
+      ).foreach { mass =>
+        UserCredV2App.sanitizeMass(mass) shouldBe 0.0
+      }
+    }
+  }
+}

--- a/user-cred-v2/ValidUserInfo.scala
+++ b/user-cred-v2/ValidUserInfo.scala
@@ -5,15 +5,7 @@ import com.twitter.usersource.snapshot.flat.thriftscala.FlatUser
 final case class ValidUserInfo(
   id: Long,
   isNearZero: Boolean,
-  isBlueVerified: Boolean,
-  isGrayVerified: Boolean,
-  isGoldVerified: Boolean,
-  isVerifiedOrg: Boolean,
-  isVOAffiliate: Boolean,
-) {
-  def isPremium: Boolean =
-    isBlueVerified || isGrayVerified || isGoldVerified || isVerifiedOrg || isVOAffiliate
-}
+)
 
 object ValidUserInfo {
   private val NearZeroState = 1
@@ -29,11 +21,6 @@ object ValidUserInfo {
         ValidUserInfo(
           id = id,
           isNearZero = flatUser.userState.contains(NearZeroState),
-          isBlueVerified = flatUser.isBlueVerified.getOrElse(false),
-          isGrayVerified = flatUser.isGrayVerified.getOrElse(false),
-          isGoldVerified = flatUser.isGoldVerified.getOrElse(false),
-          isVerifiedOrg = flatUser.isVerifiedOrganization.getOrElse(false),
-          isVOAffiliate = flatUser.isVerifiedOrganizationAffiliate.getOrElse(false),
         )
       }
     } else {


### PR DESCRIPTION
## Summary
- make the uniform UserCred V2 teleport prior include every eligible non-near-zero account equally
- remove Premium and verification fields from the UserCred input projection
- preserve engagement-derived teleport mass and beta blending
- sanitize invalid mass before normalization and add neutral-prior metrics/tests

## Why
Subscription and verification status should not provide structural prior mass in an account-credibility score used by downstream systems.

## Verification
- scanned UserCred V2 for remaining Premium/verification field dependencies
- added eligibility, near-zero, finite-positive, and invalid-mass tests
- `git diff --check` / `git show --check`

The public UserCred snapshot has no Scala build target and this environment has no Scala toolchain, so the added tests could not be executed locally.