### PR TITLE
Backfill candidates after late filtering

### DIFF
--- a/candidate-pipeline/candidate_pipeline.rs
+++ b/candidate-pipeline/candidate_pipeline.rs
@@ -90,6 +90,13 @@ where
     fn post_selection_filters(&self) -> &[Box<dyn Filter<Q, C>>];
     fn side_effects(&self) -> Arc<Vec<Box<dyn SideEffect<Q, C>>>>;
     fn result_size(&self) -> usize;
+    /// Whether `Selector::non_selected` is a ranked reserve that is safe to hydrate and serve.
+    ///
+    /// Custom selectors may use `non_selected` for side-effect accounting or placeholders, so
+    /// backfill must be explicitly enabled by pipelines whose selector guarantees real candidates.
+    fn enable_post_selection_backfill(&self) -> bool {
+        false
+    }
     fn finalize(&self, _query: &Q, _candidates: &mut Vec<C>) {}
 
     #[xai_stats_macro::receive_stats(latency=Bucket500To2500)]
@@ -126,7 +133,7 @@ where
             filtered: post_selection_filtered_candidates,
             non_selected: non_selected_candidates,
         } = self
-            .post_selection_with_backfill(
+            .post_selection(
                 &hydrated_query,
                 selected_candidates,
                 non_selected_candidates,
@@ -152,6 +159,33 @@ where
             filtered_candidates,
             selected_candidates: final_candidates,
             query: arc_hydrated_query,
+        }
+    }
+
+    async fn post_selection(
+        &self,
+        query: &Q,
+        selected_candidates: Vec<C>,
+        mut non_selected_candidates: Vec<C>,
+    ) -> PostSelectionResult<C> {
+        if self.enable_post_selection_backfill() {
+            return self
+                .post_selection_with_backfill(query, selected_candidates, non_selected_candidates)
+                .await;
+        }
+
+        // Preserve the original single-pass contract for selectors whose `non_selected` output
+        // is not a serveable reserve (for example, synthetic side-effect placeholders).
+        let hydrated = self
+            .hydrate_post_selection(query, selected_candidates)
+            .await;
+        let (mut selected, filtered) = self.filter_post_selection(query, hydrated);
+        let truncated = selected.split_off(self.result_size().min(selected.len()));
+        non_selected_candidates.extend(truncated);
+        PostSelectionResult {
+            selected,
+            filtered,
+            non_selected: non_selected_candidates,
         }
     }
 
@@ -600,6 +634,25 @@ mod tests {
         }
     }
 
+    struct PlaceholderSelector;
+
+    impl Selector<TestQuery, TestCandidate> for PlaceholderSelector {
+        fn select(
+            &self,
+            _query: &TestQuery,
+            candidates: Vec<TestCandidate>,
+        ) -> SelectResult<TestCandidate> {
+            SelectResult {
+                selected: candidates,
+                non_selected: vec![TestCandidate::new(999), TestCandidate::new(1000)],
+            }
+        }
+
+        fn score(&self, candidate: &TestCandidate) -> f64 {
+            -(candidate.id as f64)
+        }
+    }
+
     struct TestPipeline {
         query_hydrators: Vec<Box<dyn QueryHydrator<TestQuery>>>,
         sources: Vec<Box<dyn Source<TestQuery, TestCandidate>>>,
@@ -611,6 +664,7 @@ mod tests {
         post_selection_filters: Vec<Box<dyn Filter<TestQuery, TestCandidate>>>,
         side_effects: Arc<Vec<Box<dyn SideEffect<TestQuery, TestCandidate>>>>,
         result_size: usize,
+        enable_backfill: bool,
     }
 
     impl CandidatePipeline<TestQuery, TestCandidate> for TestPipeline {
@@ -653,6 +707,10 @@ mod tests {
         fn result_size(&self) -> usize {
             self.result_size
         }
+
+        fn enable_post_selection_backfill(&self) -> bool {
+            self.enable_backfill
+        }
     }
 
     fn pipeline(
@@ -685,6 +743,7 @@ mod tests {
             post_selection_filters,
             side_effects: Arc::new(vec![]),
             result_size,
+            enable_backfill: true,
         };
         (pipeline, batches)
     }
@@ -695,6 +754,34 @@ mod tests {
 
     fn ids(candidates: &[TestCandidate]) -> Vec<usize> {
         candidates.iter().map(|candidate| candidate.id).collect()
+    }
+
+    #[tokio::test]
+    async fn default_pipeline_never_hydrates_or_promotes_non_selected_placeholders() {
+        let (mut pipeline, batches) = pipeline(3, [0]);
+        pipeline.enable_backfill = false;
+        pipeline.selector = Box::new(PlaceholderSelector);
+        let selector_result = pipeline.select(&TestQuery::default(), candidates(0..3));
+        let placeholders = selector_result.non_selected.clone();
+
+        let result = pipeline
+            .post_selection(
+                &TestQuery::default(),
+                selector_result.selected,
+                selector_result.non_selected,
+            )
+            .await;
+
+        assert_eq!(ids(&result.selected), vec![1, 2]);
+        assert_eq!(ids(&result.filtered), vec![0]);
+        assert_eq!(result.non_selected, placeholders);
+        assert_eq!(*batches.lock().unwrap(), vec![vec![0, 1, 2]]);
+        assert!(
+            result
+                .non_selected
+                .iter()
+                .all(|candidate| !candidate.hydrated)
+        );
     }
 
     #[tokio::test]

--- a/candidate-pipeline/candidate_pipeline.rs
+++ b/candidate-pipeline/candidate_pipeline.rs
@@ -11,6 +11,7 @@ use crate::util;
 use crate::SPAN_LEVEL;
 use futures::future::join_all;
 use std::any::type_name_of_val;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Instant;
 use tonic::async_trait;
@@ -44,6 +45,12 @@ pub struct PipelineResult<Q, C> {
     pub filtered_candidates: Vec<C>,
     pub selected_candidates: Vec<C>,
     pub query: Arc<Q>,
+}
+
+pub struct PostSelectionResult<C> {
+    pub selected: Vec<C>,
+    pub filtered: Vec<C>,
+    pub non_selected: Vec<C>,
 }
 
 impl<Q: Default, C> PipelineResult<Q, C> {
@@ -111,20 +118,21 @@ where
 
         let SelectResult {
             selected: selected_candidates,
-            non_selected: mut non_selected_candidates,
+            non_selected: non_selected_candidates,
         } = self.select(&hydrated_query, scored_candidates);
 
-        let post_selection_hydrated_candidates = self
-            .hydrate_post_selection(&hydrated_query, selected_candidates)
+        let PostSelectionResult {
+            selected: mut final_candidates,
+            filtered: post_selection_filtered_candidates,
+            non_selected: non_selected_candidates,
+        } = self
+            .post_selection_with_backfill(
+                &hydrated_query,
+                selected_candidates,
+                non_selected_candidates,
+            )
             .await;
-
-        let (mut final_candidates, post_selection_filtered_candidates) =
-            self.filter_post_selection(&hydrated_query, post_selection_hydrated_candidates);
         filtered_candidates.extend(post_selection_filtered_candidates);
-
-        let truncated_candidates =
-            final_candidates.split_off(self.result_size().min(final_candidates.len()));
-        non_selected_candidates.extend(truncated_candidates);
 
         self.finalize(&hydrated_query, &mut final_candidates);
 
@@ -144,6 +152,48 @@ where
             filtered_candidates,
             selected_candidates: final_candidates,
             query: arc_hydrated_query,
+        }
+    }
+
+    async fn post_selection_with_backfill(
+        &self,
+        query: &Q,
+        selected_candidates: Vec<C>,
+        non_selected_candidates: Vec<C>,
+    ) -> PostSelectionResult<C> {
+        let result_size = self.result_size();
+        // Preserve the selector's reserve order while removing every attempted candidate from
+        // the non-selected side-effect bucket exactly once.
+        let mut reserve: VecDeque<C> = non_selected_candidates.into();
+        let mut filtered = Vec::new();
+
+        let hydrated = self
+            .hydrate_post_selection(query, selected_candidates)
+            .await;
+        let (mut selected, removed) = self.filter_post_selection(query, hydrated);
+        filtered.extend(removed);
+
+        while selected.len() < result_size && !reserve.is_empty() {
+            let needed = result_size - selected.len();
+            let batch_size = needed.min(reserve.len());
+            let batch: Vec<C> = reserve.drain(..batch_size).collect();
+            let hydrated = self.hydrate_post_selection(query, batch).await;
+            selected.extend(hydrated);
+            // Some late filters evaluate relationships across the whole slate (for example,
+            // conversation deduplication), so a reserve batch cannot be filtered in isolation.
+            let (kept, removed) = self.filter_post_selection(query, selected);
+            selected = kept;
+            filtered.extend(removed);
+        }
+
+        let truncated = selected.split_off(result_size.min(selected.len()));
+        let mut non_selected: Vec<C> = reserve.into_iter().collect();
+        non_selected.extend(truncated);
+
+        PostSelectionResult {
+            selected,
+            filtered,
+            non_selected,
         }
     }
 
@@ -422,5 +472,317 @@ where
                 receiver.incr(metric_name.as_str(), &FINAL_RESULT_EMPTY_SCOPE, 1u64);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filter::FilterResult;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    #[derive(Clone, Default)]
+    struct TestQuery {
+        params: xai_feature_switches::Params,
+    }
+
+    impl PipelineQuery for TestQuery {
+        fn params(&self) -> &xai_feature_switches::Params {
+            &self.params
+        }
+
+        fn decider(&self) -> Option<&xai_decider::Decider> {
+            None
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct TestCandidate {
+        id: usize,
+        group: usize,
+        hydrated: bool,
+    }
+
+    impl TestCandidate {
+        fn new(id: usize) -> Self {
+            Self {
+                id,
+                group: id,
+                hydrated: false,
+            }
+        }
+
+        fn with_group(id: usize, group: usize) -> Self {
+            Self {
+                id,
+                group,
+                hydrated: false,
+            }
+        }
+    }
+
+    struct RecordingHydrator {
+        batches: Arc<Mutex<Vec<Vec<usize>>>>,
+    }
+
+    #[async_trait]
+    impl Hydrator<TestQuery, TestCandidate> for RecordingHydrator {
+        async fn hydrate(
+            &self,
+            _query: &TestQuery,
+            candidates: &[TestCandidate],
+        ) -> Vec<Result<TestCandidate, String>> {
+            self.batches
+                .lock()
+                .unwrap()
+                .push(candidates.iter().map(|candidate| candidate.id).collect());
+            candidates
+                .iter()
+                .cloned()
+                .map(|mut candidate| {
+                    candidate.hydrated = true;
+                    Ok(candidate)
+                })
+                .collect()
+        }
+
+        fn update(&self, candidate: &mut TestCandidate, hydrated: TestCandidate) {
+            candidate.hydrated = hydrated.hydrated;
+        }
+    }
+
+    struct DropIdsFilter {
+        ids: HashSet<usize>,
+    }
+
+    impl Filter<TestQuery, TestCandidate> for DropIdsFilter {
+        fn filter(
+            &self,
+            _query: &TestQuery,
+            candidates: Vec<TestCandidate>,
+        ) -> FilterResult<TestCandidate> {
+            let (removed, kept): (Vec<_>, Vec<_>) = candidates
+                .into_iter()
+                .partition(|candidate| self.ids.contains(&candidate.id));
+            assert!(kept.iter().all(|candidate| candidate.hydrated));
+            FilterResult { kept, removed }
+        }
+    }
+
+    struct DedupGroupFilter;
+
+    impl Filter<TestQuery, TestCandidate> for DedupGroupFilter {
+        fn filter(
+            &self,
+            _query: &TestQuery,
+            candidates: Vec<TestCandidate>,
+        ) -> FilterResult<TestCandidate> {
+            let mut seen = HashSet::new();
+            let mut kept = Vec::new();
+            let mut removed = Vec::new();
+            for candidate in candidates {
+                if seen.insert(candidate.group) {
+                    kept.push(candidate);
+                } else {
+                    removed.push(candidate);
+                }
+            }
+            FilterResult { kept, removed }
+        }
+    }
+
+    struct ScoreSelector;
+
+    impl Selector<TestQuery, TestCandidate> for ScoreSelector {
+        fn score(&self, candidate: &TestCandidate) -> f64 {
+            -(candidate.id as f64)
+        }
+    }
+
+    struct TestPipeline {
+        query_hydrators: Vec<Box<dyn QueryHydrator<TestQuery>>>,
+        sources: Vec<Box<dyn Source<TestQuery, TestCandidate>>>,
+        hydrators: Vec<Box<dyn Hydrator<TestQuery, TestCandidate>>>,
+        filters: Vec<Box<dyn Filter<TestQuery, TestCandidate>>>,
+        scorers: Vec<Box<dyn Scorer<TestQuery, TestCandidate>>>,
+        selector: Box<dyn Selector<TestQuery, TestCandidate>>,
+        post_selection_hydrators: Vec<Box<dyn Hydrator<TestQuery, TestCandidate>>>,
+        post_selection_filters: Vec<Box<dyn Filter<TestQuery, TestCandidate>>>,
+        side_effects: Arc<Vec<Box<dyn SideEffect<TestQuery, TestCandidate>>>>,
+        result_size: usize,
+    }
+
+    impl CandidatePipeline<TestQuery, TestCandidate> for TestPipeline {
+        fn query_hydrators(&self) -> &[Box<dyn QueryHydrator<TestQuery>>] {
+            &self.query_hydrators
+        }
+
+        fn sources(&self) -> &[Box<dyn Source<TestQuery, TestCandidate>>] {
+            &self.sources
+        }
+
+        fn hydrators(&self) -> &[Box<dyn Hydrator<TestQuery, TestCandidate>>] {
+            &self.hydrators
+        }
+
+        fn filters(&self) -> &[Box<dyn Filter<TestQuery, TestCandidate>>] {
+            &self.filters
+        }
+
+        fn scorers(&self) -> &[Box<dyn Scorer<TestQuery, TestCandidate>>] {
+            &self.scorers
+        }
+
+        fn selector(&self) -> &dyn Selector<TestQuery, TestCandidate> {
+            self.selector.as_ref()
+        }
+
+        fn post_selection_hydrators(&self) -> &[Box<dyn Hydrator<TestQuery, TestCandidate>>] {
+            &self.post_selection_hydrators
+        }
+
+        fn post_selection_filters(&self) -> &[Box<dyn Filter<TestQuery, TestCandidate>>] {
+            &self.post_selection_filters
+        }
+
+        fn side_effects(&self) -> Arc<Vec<Box<dyn SideEffect<TestQuery, TestCandidate>>>> {
+            Arc::clone(&self.side_effects)
+        }
+
+        fn result_size(&self) -> usize {
+            self.result_size
+        }
+    }
+
+    fn pipeline(
+        result_size: usize,
+        dropped_ids: impl IntoIterator<Item = usize>,
+    ) -> (TestPipeline, Arc<Mutex<Vec<Vec<usize>>>>) {
+        pipeline_with_filters(
+            result_size,
+            vec![Box::new(DropIdsFilter {
+                ids: dropped_ids.into_iter().collect(),
+            })],
+        )
+    }
+
+    fn pipeline_with_filters(
+        result_size: usize,
+        post_selection_filters: Vec<Box<dyn Filter<TestQuery, TestCandidate>>>,
+    ) -> (TestPipeline, Arc<Mutex<Vec<Vec<usize>>>>) {
+        let batches = Arc::new(Mutex::new(Vec::new()));
+        let pipeline = TestPipeline {
+            query_hydrators: vec![],
+            sources: vec![],
+            hydrators: vec![],
+            filters: vec![],
+            scorers: vec![],
+            selector: Box::new(ScoreSelector),
+            post_selection_hydrators: vec![Box::new(RecordingHydrator {
+                batches: Arc::clone(&batches),
+            })],
+            post_selection_filters,
+            side_effects: Arc::new(vec![]),
+            result_size,
+        };
+        (pipeline, batches)
+    }
+
+    fn candidates(range: std::ops::Range<usize>) -> Vec<TestCandidate> {
+        range.map(TestCandidate::new).collect()
+    }
+
+    fn ids(candidates: &[TestCandidate]) -> Vec<usize> {
+        candidates.iter().map(|candidate| candidate.id).collect()
+    }
+
+    #[tokio::test]
+    async fn backfills_after_more_than_selector_oversampling_is_filtered() {
+        let (pipeline, batches) = pipeline(35, 0..20);
+        let result = pipeline
+            .post_selection_with_backfill(
+                &TestQuery::default(),
+                candidates(0..50),
+                candidates(50..70),
+            )
+            .await;
+
+        assert_eq!(ids(&result.selected), (20..55).collect::<Vec<_>>());
+        assert_eq!(ids(&result.filtered), (0..20).collect::<Vec<_>>());
+        assert_eq!(ids(&result.non_selected), (55..70).collect::<Vec<_>>());
+        assert_eq!(
+            *batches.lock().unwrap(),
+            vec![(0..50).collect::<Vec<_>>(), (50..55).collect::<Vec<_>>()]
+        );
+
+        let all_ids: Vec<_> = result
+            .selected
+            .iter()
+            .chain(&result.filtered)
+            .chain(&result.non_selected)
+            .map(|candidate| candidate.id)
+            .collect();
+        assert_eq!(all_ids.len(), 70);
+        assert_eq!(all_ids.iter().copied().collect::<HashSet<_>>().len(), 70);
+    }
+
+    #[tokio::test]
+    async fn filters_reserve_incrementally_without_reordering_survivors() {
+        let dropped = (0..20).chain([50, 52, 54]);
+        let (pipeline, batches) = pipeline(35, dropped);
+        let result = pipeline
+            .post_selection_with_backfill(
+                &TestQuery::default(),
+                candidates(0..50),
+                candidates(50..70),
+            )
+            .await;
+
+        let expected_selected: Vec<_> = (20..50).chain([51, 53, 55, 56, 57]).collect();
+        let expected_filtered: Vec<_> = (0..20).chain([50, 52, 54]).collect();
+        assert_eq!(ids(&result.selected), expected_selected);
+        assert_eq!(ids(&result.filtered), expected_filtered);
+        assert_eq!(ids(&result.non_selected), (58..70).collect::<Vec<_>>());
+        assert_eq!(
+            *batches.lock().unwrap(),
+            vec![
+                (0..50).collect::<Vec<_>>(),
+                (50..55).collect::<Vec<_>>(),
+                (55..58).collect::<Vec<_>>()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reserve_filters_see_already_selected_candidates() {
+        let (pipeline, batches) = pipeline_with_filters(
+            5,
+            vec![
+                Box::new(DropIdsFilter {
+                    ids: HashSet::from([0]),
+                }),
+                Box::new(DedupGroupFilter),
+            ],
+        );
+        let result = pipeline
+            .post_selection_with_backfill(
+                &TestQuery::default(),
+                candidates(0..5),
+                vec![
+                    TestCandidate::with_group(5, 1),
+                    TestCandidate::new(6),
+                    TestCandidate::new(7),
+                ],
+            )
+            .await;
+
+        assert_eq!(ids(&result.selected), vec![1, 2, 3, 4, 6]);
+        assert_eq!(ids(&result.filtered), vec![0, 5]);
+        assert_eq!(ids(&result.non_selected), vec![7]);
+        assert_eq!(
+            *batches.lock().unwrap(),
+            vec![vec![0, 1, 2, 3, 4], vec![5], vec![6]]
+        );
     }
 }

--- a/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
+++ b/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
@@ -956,6 +956,10 @@ impl CandidatePipeline<ScoredPostsQuery, PostCandidate> for PhoenixCandidatePipe
     fn result_size(&self) -> usize {
         params::RESULT_SIZE
     }
+
+    fn enable_post_selection_backfill(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add opt-in same-request reserve backfill after late filtering
- enable it only for Phoenix, whose TopK selector guarantees real ranked reserve candidates
- incrementally hydrate only the number needed and preserve whole-slate conversation deduplication
- preserve exact legacy behavior for generic/custom selectors whose `non_selected` records may be synthetic side-effect placeholders

## Verification
- tests for >15 late drops, multi-round refill, ordering, cross-batch deduplication, and candidate conservation
- regression proving default/custom pipelines never hydrate or promote synthetic placeholders
- independent post-implementation audit approved the corrected two-commit branch
- `git diff --check` / `git show --check`

The published candidate-pipeline subtree has no Cargo/BUILD manifest, so tests could not be executed locally.