### PR TITLE
Fix mute/block asymmetry: drop quotes of muted authors

### DIFF
--- a/home-mixer/filters/author_socialgraph_filter.rs
+++ b/home-mixer/filters/author_socialgraph_filter.rs
@@ -41,6 +41,10 @@ impl Filter<ScoredPostsQuery, PostCandidate> for AuthorSocialgraphFilter {
                 .retweeted_user_id
                 .map(|uid| viewer_blocked_user_ids.contains(&(uid as i64)))
                 .unwrap_or(false);
+            let viewer_mutes_quoted_author = candidate
+                .quoted_user_id
+                .map(|uid| viewer_muted_user_ids.contains(&(uid as i64)))
+                .unwrap_or(false);
 
             if muted
                 || blocked
@@ -48,6 +52,7 @@ impl Filter<ScoredPostsQuery, PostCandidate> for AuthorSocialgraphFilter {
                 || quoted_author_blocks_viewer
                 || viewer_blocks_quoted_author
                 || viewer_blocks_retweeted_user
+                || viewer_mutes_quoted_author
             {
                 removed.push(candidate);
             } else {
@@ -284,6 +289,42 @@ mod tests {
         assert_eq!(result.removed.len(), 3);
     }
 
+
+    #[tokio::test]
+    async fn test_muted_quoted_author_is_removed() {
+        let filter = AuthorSocialgraphFilter;
+        let user_features = UserFeatures {
+            muted_user_ids: vec![200],
+            ..Default::default()
+        };
+        let query = make_query_with_features(user_features);
+
+        let mut quote = make_candidate(1, 100);
+        quote.quoted_user_id = Some(200);
+
+        let candidates = vec![quote, make_candidate(3, 300)];
+        let result = filter.filter(&query, candidates);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].author_id, 300);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].quoted_user_id, Some(200));
+    }
+
+    #[tokio::test]
+    async fn test_unmuted_quoted_author_is_kept() {
+        let filter = AuthorSocialgraphFilter;
+        let query = make_query_with_features(UserFeatures::default());
+
+        let mut quote = make_candidate(1, 100);
+        quote.quoted_user_id = Some(200);
+
+        let result = filter.filter(&query, vec![quote]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].quoted_user_id, Some(200));
+        assert!(result.removed.is_empty());
+    }
     #[tokio::test]
     async fn test_author_blocks_viewer() {
         let filter = AuthorSocialgraphFilter;


### PR DESCRIPTION
## Summary
AuthorSocialgraphFilter already drops a candidate when the viewer blocks the quoted author (quoted_user_id vs blocked_user_ids). Mute only checked candidate.author_id, so a quote of a muted user still served.

This PR clones the block twin for mute. One class, one file. No ranking changes. Retweet mute stays in PR 9.

## Proof
- Entry: muted_user_ids_query_hydrator.rs writes query.user_features.muted_user_ids
- Sink: AuthorSocialgraphFilter
- Break: mute matched author_id only; quoted_user_id was block-only
- Viewer effect: F quotes muted user Q; viewer still sees the quote
- Twin: viewer_blocks_quoted_author

## Test plan
- [ ] test_muted_quoted_author_is_removed fails on main, passes on this branch
- [ ] test_unmuted_quoted_author_is_kept still keeps a quote of an unmuted user
- [ ] unit tests added; cargo test cannot run in the public dump