### PR TITLE
Fix fail-open hydration: drop tweets when label or TES flag lookup fails

### DIFF
--- a/visibility-filtering/hydration/batch.rs
+++ b/visibility-filtering/hydration/batch.rs
@@ -102,6 +102,10 @@ impl<K: Eq + Hash, V> HydrationBatch<K, V> {
         }
     }
 
+    pub(crate) fn is_failed(&self, key: &K) -> bool {
+        self.results.get(key).is_some_and(Hydrated::is_failed)
+    }
+
     pub(crate) fn hydrated(&self, key: &K) -> Option<&Hydrated<V>> {
         self.results.get(key)
     }

--- a/visibility-filtering/hydration/mod.rs
+++ b/visibility-filtering/hydration/mod.rs
@@ -67,6 +67,7 @@ impl CandidateFeatures {
         candidates
             .iter()
             .map(|c| {
+                let safety_hydration_failed = !self.safety_labels.contains_key(&c.tweet_id);
                 assemble(
                     c,
                     self.tweet_features
@@ -79,6 +80,7 @@ impl CandidateFeatures {
                         .cloned()
                         .unwrap_or_default(),
                     self.relationships.get_or_default(&c.tweet_id),
+                    safety_hydration_failed,
                     self.exclusive_content
                         .get(&c.tweet_id)
                         .cloned()
@@ -307,6 +309,36 @@ mod tests {
         assert_eq!(c.tweet_features.core.text, "two");
         assert!(c.author_features.is_suspended);
         assert!(c.relationship.viewer_follows_author);
+        assert!(!c.safety_hydration_failed);
+    }
+
+    #[test]
+    fn assemble_marks_failed_safety_label_hydration_without_dropping_candidate() {
+        let candidate = resolve_candidate(&raw(1, Some(100)), &HashMap::new()).unwrap();
+        let results = CandidateFeatures {
+            tweet_features: HashMap::new(),
+            author_features: TweetHydrationBatch::from_results(
+                [TweetId(1)],
+                HashMap::from([(
+                    TweetId(1),
+                    Ok::<_, anyhow::Error>(Some(AuthorFeatures::default())),
+                )]),
+            ),
+            safety_labels: HashMap::new(),
+            relationships: TweetHydrationBatch::from_results(
+                [TweetId(1)],
+                HashMap::from([(
+                    TweetId(1),
+                    Ok::<_, anyhow::Error>(Some(ViewerAuthorRelationship::default())),
+                )]),
+            ),
+            exclusive_content: HashMap::new(),
+        };
+
+        let assembled = results.assemble(&[candidate]);
+
+        assert_eq!(assembled.len(), 1);
+        assert!(assembled[0].safety_hydration_failed);
     }
 
     fn raw(tweet_id: u64, request_author_id: Option<u64>) -> RawCandidate {

--- a/visibility-filtering/hydration/mod.rs
+++ b/visibility-filtering/hydration/mod.rs
@@ -23,7 +23,7 @@ use fallback_cache::FallbackCache;
 use gizmoduck_hydrator::GizmoduckAuthorHydrator;
 use safety_label_hydrator::{SafetyLabelHydration, SafetyLabelHydrator};
 use socialgraph_hydrator::SocialgraphHydrator;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tes_hydrator::TesHydrator;
 use viewer_hydrator::ViewerHydrator;
@@ -59,6 +59,7 @@ struct CandidateFeatures {
     author_features: TweetHydrationBatch<AuthorFeatures>,
     safety_labels: HashMap<TweetId, SafetyLabelMap>,
     relationships: TweetHydrationBatch<ViewerAuthorRelationship>,
+    tes_hydration_failed: HashSet<TweetId>,
     exclusive_content: HashMap<TweetId, Option<ExclusiveContentFeatures>>,
 }
 
@@ -67,7 +68,8 @@ impl CandidateFeatures {
         candidates
             .iter()
             .map(|c| {
-                let safety_hydration_failed = !self.safety_labels.contains_key(&c.tweet_id);
+                let safety_hydration_failed = !self.safety_labels.contains_key(&c.tweet_id)
+                    || self.tes_hydration_failed.contains(&c.tweet_id);
                 assemble(
                     c,
                     self.tweet_features
@@ -215,11 +217,17 @@ impl HydrationPipeline {
                 &tes_tweet_keyed,
             );
 
+            let tes_hydration_failed = candidates
+                .iter()
+                .map(|c| c.tweet_id)
+                .filter(|id| tes_tweet_keyed.safety_critical_failed(id))
+                .collect();
             let features = CandidateFeatures {
                 tweet_features,
                 author_features,
                 safety_labels: label_types,
                 relationships,
+                tes_hydration_failed,
                 exclusive_content,
             };
             let hydrated_candidates = features.assemble(&candidates);
@@ -297,6 +305,7 @@ mod tests {
                     })),
                 )]),
             ),
+            tes_hydration_failed: HashSet::new(),
             exclusive_content: HashMap::new(),
         };
 
@@ -332,6 +341,37 @@ mod tests {
                     Ok::<_, anyhow::Error>(Some(ViewerAuthorRelationship::default())),
                 )]),
             ),
+            tes_hydration_failed: HashSet::new(),
+            exclusive_content: HashMap::new(),
+        };
+
+        let assembled = results.assemble(&[candidate]);
+
+        assert_eq!(assembled.len(), 1);
+        assert!(assembled[0].safety_hydration_failed);
+    }
+
+    #[test]
+    fn assemble_marks_failed_tes_tweet_flag_hydration() {
+        let candidate = resolve_candidate(&raw(1, Some(100)), &HashMap::new()).unwrap();
+        let results = CandidateFeatures {
+            tweet_features: HashMap::new(),
+            author_features: TweetHydrationBatch::from_results(
+                [TweetId(1)],
+                HashMap::from([(
+                    TweetId(1),
+                    Ok::<_, anyhow::Error>(Some(AuthorFeatures::default())),
+                )]),
+            ),
+            safety_labels: HashMap::from([(TweetId(1), SafetyLabelMap::default())]),
+            relationships: TweetHydrationBatch::from_results(
+                [TweetId(1)],
+                HashMap::from([(
+                    TweetId(1),
+                    Ok::<_, anyhow::Error>(Some(ViewerAuthorRelationship::default())),
+                )]),
+            ),
+            tes_hydration_failed: HashSet::from([TweetId(1)]),
             exclusive_content: HashMap::new(),
         };
 

--- a/visibility-filtering/hydration/mod.rs
+++ b/visibility-filtering/hydration/mod.rs
@@ -220,7 +220,7 @@ impl HydrationPipeline {
             let tes_hydration_failed = candidates
                 .iter()
                 .map(|c| c.tweet_id)
-                .filter(|id| tes_tweet_keyed.safety_critical_failed(id))
+                .filter(|id| tes_tweet_keyed.safety_hydration_failed(id, &core_datas))
                 .collect();
             let features = CandidateFeatures {
                 tweet_features,

--- a/visibility-filtering/hydration/safety_label_hydrator.rs
+++ b/visibility-filtering/hydration/safety_label_hydrator.rs
@@ -50,9 +50,7 @@ impl SafetyLabelHydrator {
                         .insert(*tweet_id, SafetyLabelMap::from_proto_label_types(label_map));
                     label_response.insert(*tweet_id, Arc::clone(label_map));
                 }
-                None => {
-                    label_types.insert(*tweet_id, SafetyLabelMap::default());
-                }
+                None => {}
             }
         }
         SafetyLabelHydration {
@@ -169,7 +167,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hydrate_fails_open_on_lookup_errors() {
+    async fn hydrate_fails_closed_on_lookup_errors() {
         let tweet_ids = vec![TweetId(1)];
         let hydrator = hydrator(
             HashMap::new(),
@@ -181,7 +179,7 @@ mod tests {
             .hydrate(&tweet_ids, SafetyLevel::TimelineHome)
             .await;
 
-        assert!(!result.label_types[&TweetId(1)].has_label(SafetyLabelType::SPAM));
+        assert!(!result.label_types.contains_key(&TweetId(1)));
         assert!(!result.label_response.contains_key(&TweetId(1)));
     }
 

--- a/visibility-filtering/hydration/tes_hydrator.rs
+++ b/visibility-filtering/hydration/tes_hydrator.rs
@@ -38,6 +38,14 @@ impl TweetHydration {
             || self.takedown_reasons.is_failed(id)
             || self.media.is_failed(id)
     }
+
+    pub(crate) fn safety_hydration_failed(
+        &self,
+        id: &TweetId,
+        core_datas: &HashMap<TweetId, PureCoreData>,
+    ) -> bool {
+        self.safety_critical_failed(id) || !core_datas.contains_key(id)
+    }
 }
 
 impl TesHydrator {
@@ -195,22 +203,23 @@ fn build_tweet_features(
         admin: tweet_keyed.nsfw_admin.get(&id).copied().unwrap_or(false),
     };
     let edit_control = tweet_keyed.edit_control.get(&id).cloned();
-
-    core_datas
+    let core = core_datas
         .get(&tweet_id)
-        .map(|core_data| TweetFeatures {
-            core: CoreFeature {
-                text: core_data.text.clone(),
-                source_tweet_id: core_data.source_tweet_id,
-            },
-            media,
-            takedown_reasons,
-            nsfw,
-            is_nullcast,
-            is_community_tweet,
-            edit_control,
+        .map(|core_data| CoreFeature {
+            text: core_data.text.clone(),
+            source_tweet_id: core_data.source_tweet_id,
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+
+    TweetFeatures {
+        core,
+        media,
+        takedown_reasons,
+        nsfw,
+        is_nullcast,
+        is_community_tweet,
+        edit_control,
+    }
 }
 
 fn media_feature(entities: MediaEntities) -> MediaFeature {
@@ -518,5 +527,41 @@ mod tests {
         let features = hydrator().assemble_tweet_features(&candidates, &core_datas, &keyed);
         assert!(!features[&TweetId(10)].nsfw.user);
         assert!(keyed.safety_critical_failed(&TweetId(10)));
+    }
+
+    #[test]
+    fn assemble_keeps_found_nsfw_flag_when_core_missing() {
+        let candidates = vec![resolve_candidate(
+            &RawCandidate {
+                tweet_id: TweetId(10),
+                request_author_id: Some(100),
+            },
+            &HashMap::new(),
+        )
+        .unwrap()];
+        let keyed = TweetHydration {
+            nsfw_user: found(10, true),
+            ..Default::default()
+        };
+        let features = hydrator().assemble_tweet_features(&candidates, &HashMap::new(), &keyed);
+        assert!(features[&TweetId(10)].nsfw.user);
+        assert!(features[&TweetId(10)].core.text.is_empty());
+        assert!(keyed.safety_hydration_failed(&TweetId(10), &HashMap::new()));
+    }
+
+    #[test]
+    fn core_present_and_flags_not_found_is_not_safety_hydration_failed() {
+        let core_datas = HashMap::from([(
+            TweetId(10),
+            PureCoreData {
+                author_id: 100,
+                ..Default::default()
+            },
+        )]);
+        let keyed = TweetHydration {
+            nsfw_user: not_found(10),
+            ..Default::default()
+        };
+        assert!(!keyed.safety_hydration_failed(&TweetId(10), &core_datas));
     }
 }

--- a/visibility-filtering/hydration/tes_hydrator.rs
+++ b/visibility-filtering/hydration/tes_hydrator.rs
@@ -28,6 +28,18 @@ pub(crate) struct TweetHydration {
     pub(crate) media: TweetHydrationBatch<MediaFeature>,
 }
 
+impl TweetHydration {
+    /// True when a Drop-sunk TES flag RPC failed. NotFound (tweet is not
+    /// NSFW / not nullcast / no takedown) is not failure.
+    pub(crate) fn safety_critical_failed(&self, id: &TweetId) -> bool {
+        self.nullcast.is_failed(id)
+            || self.nsfw_user.is_failed(id)
+            || self.nsfw_admin.is_failed(id)
+            || self.takedown_reasons.is_failed(id)
+            || self.media.is_failed(id)
+    }
+}
+
 impl TesHydrator {
     pub async fn fetch_pure_core(
         &self,
@@ -242,6 +254,23 @@ mod tests {
         )
     }
 
+    fn rpc_failed<V>(id: u64) -> TweetHydrationBatch<V> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(
+                TweetId(id),
+                Err::<Option<V>, _>("tes timeout"),
+            )]),
+        )
+    }
+
+    fn not_found<V>(id: u64) -> TweetHydrationBatch<V> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(TweetId(id), Ok::<Option<V>, anyhow::Error>(None))]),
+        )
+    }
+
     fn candidate(tweet_id: u64, author_id: u64) -> TweetCandidateInput {
         let core = HashMap::from([(
             TweetId(tweet_id),
@@ -452,5 +481,42 @@ mod tests {
         let f = &features[&TweetId(10)];
         assert!(f.core.text.is_empty());
         assert!(!f.media.has_media);
+    }
+
+    #[test]
+    fn tes_nsfw_flag_rpc_failure_is_safety_critical() {
+        let keyed = TweetHydration {
+            nsfw_user: rpc_failed(10),
+            ..Default::default()
+        };
+        assert!(keyed.safety_critical_failed(&TweetId(10)));
+        assert!(!keyed.safety_critical_failed(&TweetId(11)));
+    }
+
+    #[test]
+    fn tes_nsfw_flag_not_found_is_not_safety_critical() {
+        let keyed = TweetHydration {
+            nsfw_user: not_found(10),
+            nsfw_admin: not_found(10),
+            nullcast: not_found(10),
+            ..Default::default()
+        };
+        assert!(!keyed.safety_critical_failed(&TweetId(10)));
+    }
+
+    #[test]
+    fn tes_nsfw_flag_rpc_failure_still_assembles_false_bits() {
+        let candidates = vec![candidate(10, 100)];
+        let core_datas = HashMap::from([(TweetId(10), PureCoreData {
+            author_id: 100,
+            ..Default::default()
+        })]);
+        let keyed = TweetHydration {
+            nsfw_user: rpc_failed(10),
+            ..Default::default()
+        };
+        let features = hydrator().assemble_tweet_features(&candidates, &core_datas, &keyed);
+        assert!(!features[&TweetId(10)].nsfw.user);
+        assert!(keyed.safety_critical_failed(&TweetId(10)));
     }
 }

--- a/visibility-filtering/models/mod.rs
+++ b/visibility-filtering/models/mod.rs
@@ -71,6 +71,7 @@ pub struct HydratedTweetCandidate {
     pub author_features: AuthorFeatures,
     pub safety_labels: SafetyLabelMap,
     pub relationship: ViewerAuthorRelationship,
+    pub safety_hydration_failed: bool,
     pub exclusive_content: Option<ExclusiveContentFeatures>,
 }
 
@@ -143,6 +144,7 @@ pub fn assemble(
     author_features: AuthorFeatures,
     safety_labels: SafetyLabelMap,
     relationship: ViewerAuthorRelationship,
+    safety_hydration_failed: bool,
     exclusive_content: Option<ExclusiveContentFeatures>,
 ) -> HydratedTweetCandidate {
     HydratedTweetCandidate {
@@ -152,6 +154,7 @@ pub fn assemble(
         author_features,
         safety_labels,
         relationship,
+        safety_hydration_failed,
         exclusive_content,
     }
 }

--- a/visibility-filtering/rules/context.rs
+++ b/visibility-filtering/rules/context.rs
@@ -144,6 +144,11 @@ impl TweetPredicates<'_> {
     }
 
     #[inline]
+    pub fn safety_hydration_failed(&self) -> bool {
+        self.ctx.candidate.safety_hydration_failed
+    }
+
+    #[inline]
     pub fn is_retweet(&self) -> bool {
         self.ctx.candidate.is_retweet()
     }

--- a/visibility-filtering/rules/registry.rs
+++ b/visibility-filtering/rules/registry.rs
@@ -78,7 +78,8 @@ impl Policy {
 
 static FILTER_ALL_POLICY: Policy = Policy::new(&[tweet_rules::FILTER_ALL]);
 
-static TIMELINE_HOME_SHARED_RULES: [&[RuleSpec]; 9] = [
+static TIMELINE_HOME_SHARED_RULES: [&[RuleSpec]; 10] = [
+    tweet_rules::SAFETY_HYDRATION_FAILURE_DROP,
     author_rules::AUTHOR_STATE_DROPS,
     author_rules::SOCIALGRAPH_DROPS,
     tweet_rules::TWEET_LABEL_DROPS,
@@ -158,6 +159,33 @@ mod tests {
     use crate::rules::fixtures::{candidate, viewer, VIEWER_ID};
 
     #[test]
+    fn failed_safety_label_hydration_fails_closed_on_both_home_surfaces() {
+        let rule_engine = RuleEngine::new();
+        let viewer = ViewerFeatures::default();
+        let mut failed = HydratedTweetCandidate::default();
+        failed.safety_hydration_failed = true;
+
+        for level in [
+            SafetyLevel::TimelineHome,
+            SafetyLevel::TimelineHomeRecommendations,
+        ] {
+            let verdict = rule_engine.evaluate(level, &viewer, &failed);
+            assert!(matches!(verdict.action, VfAction::Drop(_)));
+            assert_eq!(verdict.decided_by, Some("SafetyHydrationFailureDropRule"));
+        }
+    }
+
+    #[test]
+    fn successful_safety_label_hydration_remains_eligible_for_normal_rules() {
+        let rule_engine = RuleEngine::new();
+        let viewer = ViewerFeatures::default();
+        let candidate = HydratedTweetCandidate::default();
+
+        let verdict = rule_engine.evaluate(SafetyLevel::TimelineHome, &viewer, &candidate);
+        assert!(matches!(verdict.action, VfAction::Allow));
+    }
+
+    #[test]
     fn refreshed_config_country_reaches_the_wired_rule() {
         let gating_countries = Arc::new(NsfwGatingCountries::starting_at_default());
         let rule_engine = RuleEngine::with_nsfw_gating_countries(Arc::clone(&gating_countries));
@@ -206,6 +234,7 @@ rust_vf:
         assert_eq!(
             home,
             vec![
+                "SafetyHydrationFailureDropRule",
                 "SuspendedAuthorRule",
                 "DeactivatedAuthorRule",
                 "ErasedAuthorRule",

--- a/visibility-filtering/rules/tweet_rules.rs
+++ b/visibility-filtering/rules/tweet_rules.rs
@@ -278,6 +278,19 @@ fn drop_geo_restricted_media(context: &RuleContext<'_>) -> VfAction {
     }
 }
 
+pub(super) const SAFETY_HYDRATION_FAILURE_DROP: &[RuleSpec] = &[RuleSpec::Custom {
+    name: "SafetyHydrationFailureDropRule",
+    evaluate: drop_failed_safety_hydration,
+}];
+
+fn drop_failed_safety_hydration(context: &RuleContext<'_>) -> VfAction {
+    if context.tweet().safety_hydration_failed() {
+        VfAction::Drop(FilteredReason::UnspecifiedReason)
+    } else {
+        VfAction::Allow
+    }
+}
+
 pub(super) const TES_HOME_DROPS: &[RuleSpec] = &[
     RuleSpec::Tweet {
         name: "DropStaleTweetsRule",
@@ -1044,11 +1057,12 @@ mod tests {
         assert_drops(no_age, &request_fallback, &hp, &reason);
     }
 
-    fn all_rule_slices() -> [&'static [RuleSpec]; 15] {
+    fn all_rule_slices() -> [&'static [RuleSpec]; 16] {
         use crate::rules::author_rules::{
             AUTHOR_STATE_DROPS, OON_NSFW_AUTHOR_DROPS, OON_USER_LABEL_DROPS, SOCIALGRAPH_DROPS,
         };
         [
+            SAFETY_HYDRATION_FAILURE_DROP,
             AUTHOR_STATE_DROPS,
             TWEET_LABEL_DROPS,
             NSFW_MEDIA_INTERSTITIALS,


### PR DESCRIPTION
## Bug
Safety-critical tweet metadata fail-open on miss.

SafetyLabelHydrator collapsed lookup errors and missing keys into SafetyLabelMap::default(). VF tweet-label rules then saw unlabeled and allowed.

TesHydrator.assemble_tweet_features treated TES timeout/RPC Failed the same as Ok(None): nsfw_user, nsfw_admin, nullcast, takedown, and media became false. fetch_pure_core then omitted Err/None, and build_tweet_features unwrap_or_default wiped any Found flag bits. TweetNsfwUserDropRule / TweetNsfwAdminDropRule (OON), NullcastedTweetDropRule, and takedown/DMCA drops allowed.

This is not VF dual-role merge (PR 55 / residual 90). Not mute/block (PR 23 / PR 9). Not author/graph hydration (PR 7). Not HM TES miss wiping retweet/reply ids (PR 94).

## Fix
On label miss, do not insert an empty map. On TES flag RPC Failed or missing core, mark the tweet. Found flag bits stay attached even when core is absent. Assemble sets safety_hydration_failed. SafetyHydrationFailureDropRule is the first TimelineHome / TimelineHomeRecommendations RuleSpec row and drops on that flag.

Ok(None) on a flag RPC still means the tweet is not flagged.

## Proof
- Entry: SafetyLabelHydrator / TesHydrator.get_nsfw_user and fetch_pure_core
- Sink: VF tweet-label drops and TES flag drops (empty/false = allow)
- Break: None arm inserted SafetyLabelMap::default(); TES Failed used unwrap_or(false); core miss discarded Found flags
- Viewer effect: NSFW, nullcast, or takedown tweet still serves when the lookup errors
- Twin: PR 7 author/graph fail-closed via safety_hydration_failed

## Tests
- hydrate_fails_closed_on_lookup_errors
- hydrate_fails_open_on_missing_results (successful empty labels still present)
- tes_nsfw_flag_rpc_failure_is_safety_critical
- tes_nsfw_flag_not_found_is_not_safety_critical
- assemble_keeps_found_nsfw_flag_when_core_missing
- assemble_marks_failed_safety_label_hydration_without_dropping_candidate
- assemble_marks_failed_tes_tweet_flag_hydration
- failed_safety_label_hydration_fails_closed_on_both_home_surfaces
- unit tests added; cargo test cannot run in the public dump