### PR TITLE
Bound VM Ranker DPP work by the server pool limit

### DIFF
--- a/vm-ranker/args.rs
+++ b/vm-ranker/args.rs
@@ -21,7 +21,11 @@ pub struct Args {
     #[arg(long, default_value_t = 0.5)]
     pub dpp_theta: f64,
 
-    #[arg(long, default_value_t = 100)]
+    #[arg(
+        long,
+        default_value_t = 100,
+        help = "Maximum DPP candidate pool size; requests may select a smaller pool"
+    )]
     pub dpp_max_selected_rank: usize,
 
     #[arg(long, default_value_t = 1024)]

--- a/vm-ranker/scoring/mod.rs
+++ b/vm-ranker/scoring/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use log::error;
 
-use xai_vm_ranker_proto::{RankRequest, RankedCandidate};
+use xai_vm_ranker_proto::{DppParams, RankRequest, RankedCandidate};
 
 use crate::dpp::DppConfig;
 use crate::embedding_store::EmbeddingStore;
@@ -13,6 +13,16 @@ use crate::embedding_store::EmbeddingStore;
 pub struct DppContext {
     pub store: Arc<EmbeddingStore>,
     pub config: DppConfig,
+}
+
+fn apply_request_dpp_params(config: &mut DppConfig, params: &DppParams) {
+    if params.theta != 0.0 {
+        config.theta = params.theta;
+    }
+    if params.max_selected_rank != 0 {
+        config.max_selected_rank =
+            (params.max_selected_rank as usize).min(config.max_selected_rank);
+    }
 }
 
 pub async fn rank(
@@ -29,12 +39,7 @@ pub async fn rank(
         let mut ctx = ctx.clone();
 
         if let Some(params) = &req.dpp_params {
-            if params.theta != 0.0 {
-                ctx.config.theta = params.theta;
-            }
-            if params.max_selected_rank != 0 {
-                ctx.config.max_selected_rank = params.max_selected_rank as usize;
-            }
+            apply_request_dpp_params(&mut ctx.config, params);
         }
 
         let dpp_result = tokio::task::spawn_blocking(move || dpp_model::rank(&req, &ctx))
@@ -51,4 +56,57 @@ pub async fn rank(
             score: c.score.unwrap_or(0.0),
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_pool_limit(max_selected_rank: usize) -> DppConfig {
+        DppConfig {
+            top_k: 50,
+            theta: 0.5,
+            max_selected_rank,
+            debug_viewer_id: 0,
+        }
+    }
+
+    #[test]
+    fn request_cannot_raise_server_dpp_pool_limit() {
+        let mut config = config_with_pool_limit(100);
+        let params = DppParams {
+            theta: 0.0,
+            max_selected_rank: u32::MAX,
+        };
+
+        apply_request_dpp_params(&mut config, &params);
+
+        assert_eq!(config.max_selected_rank, 100);
+    }
+
+    #[test]
+    fn request_can_select_a_smaller_dpp_pool() {
+        let mut config = config_with_pool_limit(100);
+        let params = DppParams {
+            theta: 0.0,
+            max_selected_rank: 40,
+        };
+
+        apply_request_dpp_params(&mut config, &params);
+
+        assert_eq!(config.max_selected_rank, 40);
+    }
+
+    #[test]
+    fn zero_request_value_keeps_server_dpp_pool_limit() {
+        let mut config = config_with_pool_limit(100);
+        let params = DppParams {
+            theta: 0.0,
+            max_selected_rank: 0,
+        };
+
+        apply_request_dpp_params(&mut config, &params);
+
+        assert_eq!(config.max_selected_rank, 100);
+    }
 }


### PR DESCRIPTION
## Summary

Keep per-request DPP work within the pool limit selected when VM Ranker starts.

A `RankRequest` can provide `max_selected_rank`. Previously that value replaced the server setting without a ceiling. DPP builds two square matrices from this pool, so work and memory grow quadratically with the accepted value and candidate count.

The request value is now capped at `--dpp-max-selected-rank`. A request may still select a smaller pool, and zero still means "use the server value." The CLI help now states this contract.

This is a service-level resource bound. It does not assume the gRPC service is publicly reachable; it limits any caller able to submit a `RankRequest`.

## Compatibility

- Values at or below the server limit are unchanged.
- Values above the server limit now use the server limit.
- Home Mixer defaults its request value to 150, while VM Ranker's CLI default is 100. With both source defaults, the effective pool becomes 100. A deployment that intentionally needs 150 can start VM Ranker with `--dpp-max-selected-rank 150`.

## Validation

- The request-to-config test uses `u32::MAX` and confirms the server limit remains 100.
- A control confirms a request can reduce the pool from 100 to 40.
- A zero-value control confirms the server limit remains unchanged.
- Compiled and ran the exact parameter application function and all three checked-in tests with Rust 2021 in a clean container: 3 passed.
- `rustfmt --check` passes.

The public repository does not include a build manifest for `vm-ranker`, so a full service build is not available from this checkout.

