### PR TITLE
Bound Thunder Thrift containers before allocation

### DIFF
--- a/thunder/deserializer.rs
+++ b/thunder/deserializer.rs
@@ -2,22 +2,81 @@ use crate::schema::{events::Event, tweet_events::TweetEvent};
 use anyhow::{Context, Result};
 use prost::Message;
 use thrift::protocol::{TBinaryInputProtocol, TSerializable};
+use thrift::TConfiguration;
 use xai_thunder_proto::InNetworkEvent;
+
+const MAX_THRIFT_CONTAINER_ELEMENTS: usize = 100_000;
+
+fn thrift_config(payload_len: usize) -> Result<TConfiguration> {
+    TConfiguration::builder()
+        .max_message_size(Some(payload_len))
+        .max_frame_size(None)
+        .max_container_size(Some(MAX_THRIFT_CONTAINER_ELEMENTS))
+        .max_string_size(Some(payload_len))
+        .build()
+        .context("Failed to configure Thrift input limits")
+}
 
 pub fn deserialize_tweet_event(payload: &[u8]) -> Result<TweetEvent> {
     let mut cursor = std::io::Cursor::new(payload);
-    let mut protocol = TBinaryInputProtocol::new(&mut cursor, true);
+    let mut protocol =
+        TBinaryInputProtocol::with_config(&mut cursor, true, thrift_config(payload.len())?);
 
     TweetEvent::read_from_in_protocol(&mut protocol).context("Failed to deserialize TweetEvent")
 }
 
 pub fn deserialize_event(payload: &[u8]) -> Result<Event> {
     let mut cursor = std::io::Cursor::new(payload);
-    let mut protocol = TBinaryInputProtocol::new(&mut cursor, true);
+    let mut protocol =
+        TBinaryInputProtocol::with_config(&mut cursor, true, thrift_config(payload.len())?);
 
     Event::read_from_in_protocol(&mut protocol).context("Failed to deserialize Event")
 }
 
 pub fn deserialize_tweet_event_v2(payload: &[u8]) -> Result<InNetworkEvent> {
     InNetworkEvent::decode(payload).context("Failed to deserialize InNetworkEvent")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_container_length_before_preallocating_from_it() {
+        let payload = [
+            12, 0, 2, // TweetEvent.flags: struct
+            15, 0, 1, // TweetEventFlags.unused1: list
+            11, 0, 0x0f, 0x42, 0x40, // string list with 1,000,000 elements
+        ];
+
+        let error = deserialize_tweet_event(&payload).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to deserialize TweetEvent"),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            format!("{error:#}").contains("message too long"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn accepts_a_valid_string_list() {
+        let payload = [
+            12, 0, 2, // TweetEvent.flags: struct
+            15, 0, 1, // TweetEventFlags.unused1: list
+            11, 0, 0, 0, 1, // one string
+            0, 0, 0, 2, b'o', b'k', // "ok"
+            0,    // end TweetEventFlags
+            0,    // end TweetEvent
+        ];
+
+        let event = deserialize_tweet_event(&payload).expect("valid TweetEvent");
+        assert_eq!(
+            event.flags.and_then(|flags| flags.unused1),
+            Some(vec!["ok".to_owned()])
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Keep legacy Thrift event decoding from reserving memory based only on a container count declared in the payload.

Thunder's generated readers preallocate vectors from the decoded list length. Apache Thrift's default configuration limits total message size, but it has no container-element limit and does not bind that check to the bytes in the current payload. In the unmodified code, an 11-byte event declaring 1,000,000 strings reaches `Vec::with_capacity` and requests a 24 MB allocation before the first string read fails.

Both legacy deserializers now use Thrift's built-in `TConfiguration`:

- message and string limits are tied to the actual payload length
- containers have an explicit 100,000-element ceiling
- malformed lengths fail during `read_list_begin`, before generated code preallocates the vector

The protobuf v2 path and generated schema files are unchanged. A legacy event containing a collection above 100,000 elements will now be rejected.

This applies to messages consumed by Thunder's Kafka listeners. It does not imply that the topic is publicly writable; reachability depends on Kafka producer access.

## Validation

- A baseline allocator probe against the unmodified source confirms the 1,000,000-element payload requests at least 24 MB.
- The same payload is rejected by the changed decoder without a large reservation.
- A valid `TweetEvent` containing one string still deserializes correctly.
- Built the published Thunder schemas and changed deserializer in a focused Rust harness using Apache Thrift v0.23.0, the version declared by the repository's published Rust workspace: 3 tests passed.
- `rustfmt --check` passes.

The public repository does not include a build manifest for `thunder`, so a full service build is not available from this checkout.
