### PR TITLE
Fix hard-disabled enable: BroadcastLivenessHydrator param

### DIFF
--- a/home-mixer/candidate_hydrators/broadcast_liveness_hydrator.rs
+++ b/home-mixer/candidate_hydrators/broadcast_liveness_hydrator.rs
@@ -1,6 +1,7 @@
 use crate::clients::tweet_entity_service_client::TESClient;
 use crate::models::candidate::{CandidateHelpers, PostCandidate};
 use crate::models::query::ScoredPostsQuery;
+use crate::params::EnableBroadcastLivenessHydrator;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -79,7 +80,7 @@ fn broadcast_id_from_urls(urls: Option<&UrlEntities>) -> Option<String> {
 #[async_trait]
 impl Hydrator<ScoredPostsQuery, PostCandidate> for BroadcastLivenessHydrator {
     fn enable(&self, query: &ScoredPostsQuery) -> bool {
-        false
+        query.params.get(EnableBroadcastLivenessHydrator)
     }
 
     async fn hydrate(
@@ -221,6 +222,14 @@ mod tests {
             author_id: 42,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn enable_returns_false_by_default() {
+        let tes = Arc::new(MockTESClient::default());
+        let strato = MockStratoClient::default();
+        let h = BroadcastLivenessHydrator::new(tes, Arc::new(strato));
+        assert!(!h.enable(&query()));
     }
 
     #[tokio::test]

--- a/home-mixer/params/param.rs
+++ b/home-mixer/params/param.rs
@@ -950,6 +950,12 @@ param!(
     "rust_home_mixer_enable_topic_feedback_context",
     false
 );
+param!(
+    EnableBroadcastLivenessHydrator,
+    bool,
+    "rust_home_mixer_enable_broadcast_liveness_hydrator",
+    false
+);
 
 param!(
     EnablePhoenixRequestCacheSideEffect,


### PR DESCRIPTION
## Class
7 / hard-disabled enable

## What is true
BroadcastLivenessHydrator exists and writes broadcast_is_live, but enable() is a literal false, so live broadcasts never get a liveness bit.

## Proof
- Entry: BroadcastLivenessHydrator::hydrate (TES urls + Strato batch_get_broadcast_is_live)
- Sink: PostCandidate.broadcast_is_live consumed by RerankingKafkaSideEffect (no drop filter in this dump)
- Break: enable() ignored query.params and always returned false
- Viewer effect: live X broadcasts in For You never carry broadcast_is_live; ranking/kafka see None
- Twin: TopicFeedbackContextHydrator / EnableTopicFeedbackContext (param-gated enable)

## Change
- home-mixer/params/param.rs: EnableBroadcastLivenessHydrator, key rust_home_mixer_enable_broadcast_liveness_hydrator, default false
- home-mixer/candidate_hydrators/broadcast_liveness_hydrator.rs: enable() reads that param
- test: enable_returns_false_by_default

## Tests
Added enable_returns_false_by_default.
cargo: cannot run in the public dump

## Still open
- Module is still an orphan on main until PR 16 merges (pub mod broadcast_liveness_hydrator).
- Hydrator is still not pushed into any candidate_pipeline hydrators vec. Do not wire until a drop/score sink is named.
- PopularTopicsSource enable() is still a literal false (separate class).