### PR TITLE
Fix hard-disabled enable: PopularTopicsSource param

### DIFF
--- a/home-mixer/params/param.rs
+++ b/home-mixer/params/param.rs
@@ -44,6 +44,12 @@ param!(
     "rust_home_mixer_enable_tweet_mixer_source",
     false
 );
+param!(
+    EnablePopularTopicsSource,
+    bool,
+    "rust_home_mixer_enable_popular_topics_source",
+    false
+);
 
 param!(
     EnableSimclustersSource,

--- a/home-mixer/sources/popular_topics_source.rs
+++ b/home-mixer/sources/popular_topics_source.rs
@@ -1,5 +1,6 @@
 use crate::models::candidate::PostCandidate;
 use crate::models::query::ScoredPostsQuery;
+use crate::params::EnablePopularTopicsSource;
 use std::sync::Arc;
 use tonic::async_trait;
 use xai_candidate_pipeline::component_library::clients::StratoClient;
@@ -53,7 +54,9 @@ pub struct PopularTopicsSource {
 #[async_trait]
 impl Source<ScoredPostsQuery, PostCandidate> for PopularTopicsSource {
     fn enable(&self, query: &ScoredPostsQuery) -> bool {
-        false
+        query.params.get(EnablePopularTopicsSource)
+            && !query.in_network_only
+            && !query.has_cached_posts
     }
 
     async fn source(&self, query: &ScoredPostsQuery) -> Result<Vec<PostCandidate>, String> {
@@ -98,5 +101,31 @@ impl Source<ScoredPostsQuery, PostCandidate> for PopularTopicsSource {
             .collect();
 
         Ok(candidates)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_candidate_pipeline::component_library::clients::MockStratoClient;
+
+    fn source() -> PopularTopicsSource {
+        PopularTopicsSource {
+            strato_client: Arc::new(MockStratoClient::default()),
+        }
+    }
+
+    #[test]
+    fn enable_returns_false_by_default() {
+        assert!(!source().enable(&ScoredPostsQuery::default()));
+    }
+
+    #[test]
+    fn enable_returns_false_when_in_network_only() {
+        let query = ScoredPostsQuery {
+            in_network_only: true,
+            ..Default::default()
+        };
+        assert!(!source().enable(&query));
     }
 }


### PR DESCRIPTION
## Class
7 / hard-disabled enable

## What is true
PopularTopicsSource can fetch topical popular tweets from Strato and tag them ForYouPopularTopics, but enable() is a literal false, so the source never runs.

## Proof
- Entry: PopularTopicsSource::source (Strato get_popular_topic_tweets, served_type ForYouPopularTopics)
- Sink: PopularTopicsAuthorDedupFilter keeps first popular post per author; Phoenix/For You source stage would consume the vec if the source were enabled and boxed
- Break: enable() ignored query.params and always returned false
- Viewer effect: For You never receives this source's news/sports/tech/etc popular-topic candidates
- Twin: TweetMixerSource / EnableTweetMixerSource (param-gated, skip in-network and cached-posts)

## Change
- home-mixer/params/param.rs: EnablePopularTopicsSource, key rust_home_mixer_enable_popular_topics_source, default false
- home-mixer/sources/popular_topics_source.rs: enable() reads that param and clones TweetMixer in-network / cached-posts guards
- tests: enable_returns_false_by_default, enable_returns_false_when_in_network_only

## Tests
Added the two enable tests above.
cargo: cannot run in the public dump

## Still open
- Module is still an orphan on main until PR 2 merges (pub mod popular_topics_source).
- Source is still not boxed into any candidate_pipeline sources vec. Do not wire in this PR.
- PopularTopicsAuthorDedupFilter is also still unregistered on main until PR 2.
- BroadcastLiveness enable is a separate class (PR 29).