### PR TITLE
Validate redacted score-results sink policies

### DIFF
--- a/bdsm/README.md
+++ b/bdsm/README.md
@@ -124,3 +124,37 @@ The scorer publishes an 8-wide row in `heads.HEAD_NAMES` order.
   it carries that sentinel plus the model-head suffix, not the internal
   appeal paragraph or the action types each head keys off. ActionName
   proto enums are unchanged.
+
+### Results-sink policy format
+
+Pass a reviewed policy with `--policy-file PATH`, or set `BDSM_SINK_POLICY` to
+that path. The loader falls back to `runtime/sink_policy.yaml` when neither is
+set.
+
+Each entry in `thresholds`, `cusp_heads`, `paused_liveness_thresholds`, and
+`spam_bounce_thresholds` is a two-value pair:
+
+```yaml
+thresholds:
+  FollowBot: [9.99, 9.99]  # redacted and disabled in the public policy
+```
+
+The pair is `[tau, lambda]`. A head matches only when both conditions hold:
+
+```text
+head score >= tau AND LegitimateUser score <= lambda
+```
+
+For a configured policy, both values must be finite probabilities in `[0, 1]`.
+The public `9.99` value is accepted only as a complete `[9.99, 9.99]` pair; it
+marks that entry as redacted and disabled. Mixing a real value with the
+sentinel is rejected. `cusp_delta` and `reply_spam_hard_suspend_tau` follow the
+same numeric rules, and a redacted `cusp_delta` cannot be combined with active
+cusp-head thresholds.
+
+The loader fails at startup for malformed pairs, unknown model heads,
+non-finite values, out-of-range values, and inconsistent cusp or spam-bounce
+configuration. It also emits a warning listing every redacted field that still
+disables an enforcement lane. Replace those fields only with operating points
+calibrated for your own model and data; this repository does not publish or
+recommend production threshold values.

--- a/bdsm/runtime/score_results_sink_focal.py
+++ b/bdsm/runtime/score_results_sink_focal.py
@@ -3,6 +3,7 @@
 import argparse
 import datetime
 import logging
+import math
 import os
 import time
 import threading
@@ -264,6 +265,101 @@ _POLICY_2TUPLE_TABLES = (
     "paused_liveness_thresholds",
     "spam_bounce_thresholds",
 )
+_REDACTED_SENTINEL = 9.99
+_POLICY_SCORE_HEADS = frozenset(HEAD_NAMES.values()) - {"LegitimateUser"}
+
+
+def _is_redacted_pair(pair) -> bool:
+    return pair == (_REDACTED_SENTINEL, _REDACTED_SENTINEL)
+
+
+def _parse_operating_point(value, source: str, field_name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"sink policy {source}: {field_name} must be a number")
+    try:
+        point = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"sink policy {source}: {field_name} must be a number") from exc
+    if not math.isfinite(point):
+        raise ValueError(f"sink policy {source}: {field_name} must be finite")
+    if point != _REDACTED_SENTINEL and not 0.0 <= point <= 1.0:
+        raise ValueError(
+            f"sink policy {source}: {field_name} must be in [0, 1] "
+            f"or use the {_REDACTED_SENTINEL} redaction sentinel"
+        )
+    return point
+
+
+def _parse_threshold_table(name: str, value, source: str) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError(f"sink policy {source}: {name} must be a mapping")
+
+    parsed = {}
+    for raw_head, raw_pair in value.items():
+        head = str(raw_head)
+        if head not in _POLICY_SCORE_HEADS:
+            raise ValueError(f"sink policy {source}: {name}.{head} is not a model score head")
+        if not isinstance(raw_pair, (list, tuple)) or len(raw_pair) != 2:
+            raise ValueError(
+                f"sink policy {source}: {name}.{head} must contain exactly two values [tau, lambda]"
+            )
+        tau = _parse_operating_point(raw_pair[0], source, f"{name}.{head}[0]")
+        lam = _parse_operating_point(raw_pair[1], source, f"{name}.{head}[1]")
+        if (tau == _REDACTED_SENTINEL) != (lam == _REDACTED_SENTINEL):
+            raise ValueError(
+                f"sink policy {source}: {name}.{head} must use the redaction sentinel "
+                "for both values or neither value"
+            )
+        parsed[head] = (tau, lam)
+    return parsed
+
+
+def _validate_policy(policy: SinkPolicy) -> None:
+    if policy.min_actions_for_enforcement < 0:
+        raise ValueError(
+            f"sink policy {policy.source}: min_actions_for_enforcement must be non-negative"
+        )
+
+    if policy.cusp_delta == _REDACTED_SENTINEL:
+        configured_cusp_heads = [
+            head for head, pair in policy.cusp_heads.items() if not _is_redacted_pair(pair)
+        ]
+        if configured_cusp_heads:
+            raise ValueError(
+                f"sink policy {policy.source}: cusp_delta uses the redaction sentinel while "
+                f"cusp_heads contains configured heads {sorted(configured_cusp_heads)}"
+            )
+
+    missing_action_keys = set(policy.spam_bounce_thresholds) - set(policy.spam_bounce_action_key)
+    if missing_action_keys:
+        raise ValueError(
+            f"sink policy {policy.source}: spam_bounce_action_key is missing heads "
+            f"{sorted(missing_action_keys)}"
+        )
+
+
+def _redacted_policy_fields(policy: SinkPolicy) -> list[str]:
+    fields = []
+    for table_name in _POLICY_2TUPLE_TABLES:
+        table = getattr(policy, table_name)
+        fields.extend(
+            f"{table_name}.{head}" for head, pair in table.items() if _is_redacted_pair(pair)
+        )
+    for field_name in ("cusp_delta", "reply_spam_hard_suspend_tau"):
+        if getattr(policy, field_name) == _REDACTED_SENTINEL:
+            fields.append(field_name)
+    return fields
+
+
+def _warn_if_redacted(policy: SinkPolicy) -> None:
+    fields = _redacted_policy_fields(policy)
+    if fields:
+        log.warning(
+            "sink policy: REDACTED 9.99 sentinel present at %s; affected enforcement "
+            "lanes are disabled. Supply reviewed operating points via --policy-file or "
+            "BDSM_SINK_POLICY before enabling enforcement.",
+            ", ".join(fields),
+        )
 
 
 def _load_policy(path: str | None) -> SinkPolicy:
@@ -274,6 +370,7 @@ def _load_policy(path: str | None) -> SinkPolicy:
     )
     if not os.path.exists(resolved):
         log.info(f"sink policy: baked-in defaults (no policy file at {resolved})")
+        _warn_if_redacted(DEFAULT_POLICY)
         return DEFAULT_POLICY
     try:
         import yaml
@@ -281,9 +378,12 @@ def _load_policy(path: str | None) -> SinkPolicy:
         log.warning(
             f"sink policy: pyyaml unavailable, IGNORING {resolved}; using baked-in defaults"
         )
+        _warn_if_redacted(DEFAULT_POLICY)
         return DEFAULT_POLICY
     with open(resolved) as f:
         raw = yaml.safe_load(f) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"sink policy {resolved}: document root must be a mapping")
     known = {f_.name for f_ in dataclasses.fields(SinkPolicy)} - {"source"}
     unknown = set(raw) - known - {"notes"}
     if unknown:
@@ -293,7 +393,7 @@ def _load_policy(path: str | None) -> SinkPolicy:
         if k == "notes":
             continue
         if k in _POLICY_2TUPLE_TABLES:
-            kw[k] = {h: (float(t[0]), float(t[1])) for h, t in v.items()}
+            kw[k] = _parse_threshold_table(k, v, resolved)
         elif k == "official_client_app_ids":
             kw[k] = frozenset(int(x) for x in v)
         elif k == "spam_bounce_action_key":
@@ -301,11 +401,13 @@ def _load_policy(path: str | None) -> SinkPolicy:
         elif k == "min_actions_for_enforcement":
             kw[k] = int(v)
         elif k in ("cusp_delta", "reply_spam_hard_suspend_tau"):
-            kw[k] = float(v)
+            kw[k] = _parse_operating_point(v, resolved, k)
         else:
             kw[k] = str(v)
     pol = SinkPolicy(source=resolved, **kw)
+    _validate_policy(pol)
     log.info(f"sink policy: LOADED {resolved} (version={pol.version})")
+    _warn_if_redacted(pol)
     return pol
 
 
@@ -959,6 +1061,12 @@ def _decide_hard_enforcement(
 def _cusp_lane(
     uid_int, dec, user_labels, scores_by_name, legit, total_actions_gate, pol, args, r, metrics
 ):
+    # The public policy uses 9.99 for both the head pair and delta. Without an
+    # explicit guard, subtracting the two sentinels produces a zero threshold
+    # and can make the redacted cusp lane match ordinary scores.
+    if pol.cusp_delta == _REDACTED_SENTINEL:
+        return
+
     if (
         not dec.enforcement_met
         and dec.age_gate_skip_reason is None
@@ -966,6 +1074,8 @@ def _cusp_lane(
         and not dec.tweet_create_dominant
     ):
         for _h, (_tau, _lam) in pol.cusp_heads.items():
+            if _is_redacted_pair((_tau, _lam)):
+                continue
             _bot = scores_by_name.get(_h, 0)
             if _bot >= _tau - pol.cusp_delta and legit <= _lam + pol.cusp_delta:
                 dec.cusp_met = True

--- a/bdsm/tests/test_sink_policy.py
+++ b/bdsm/tests/test_sink_policy.py
@@ -1,6 +1,8 @@
 import dataclasses
 import importlib.util
+import logging
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -31,6 +33,15 @@ def test_shipped_policy_matches_baked_in_defaults():
         want.pop(k)
     assert got == want, "sink_policy.yaml drifted from the baked-in defaults"
     assert pol.min_actions_for_enforcement > 10_000
+
+
+def test_shipped_policy_warns_that_redacted_lanes_are_disabled(caplog):
+    m = _load_sink_module()
+    with caplog.at_level(logging.WARNING, logger="results_sink"):
+        m._load_policy(os.path.join(_RUNTIME, "sink_policy.yaml"))
+
+    assert "REDACTED 9.99 sentinel" in caplog.text
+    assert "affected enforcement lanes are disabled" in caplog.text
 
 
 def test_missing_policy_file_falls_back_to_defaults():
@@ -86,3 +97,117 @@ def test_enforcement_templates_are_the_redacted_sentinel():
     for tmpl in m._ENFORCEMENT_TEMPLATES.values():
         assert tmpl == m._REDACTED_TEMPLATE
     assert not hasattr(m, "_ACTION_FRIENDLY")
+
+
+def test_valid_custom_policy_documents_pair_semantics(tmp_path, caplog):
+    m = _load_sink_module()
+    policy = tmp_path / "policy.yaml"
+    policy.write_text(
+        """\
+version: test
+min_actions_for_enforcement: 10
+thresholds:
+  FollowBot: [0.8, 0.2]
+cusp_delta: 0.05
+cusp_heads: {}
+paused_liveness_thresholds: {}
+spam_bounce_thresholds: {}
+spam_bounce_action_key: {}
+reply_spam_hard_suspend_tau: 0.95
+"""
+    )
+
+    with caplog.at_level(logging.WARNING, logger="results_sink"):
+        loaded = m._load_policy(str(policy))
+
+    assert loaded.thresholds["FollowBot"] == (0.8, 0.2)
+    assert "REDACTED 9.99 sentinel" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("policy_fragment", "message"),
+    [
+        ("thresholds: []\n", "thresholds must be a mapping"),
+        ("thresholds:\n  FollowBot: [0.8]\n", "exactly two values"),
+        ("thresholds:\n  FollowBot: [nope, 0.2]\n", "must be a number"),
+        ("thresholds:\n  FollowBot: [.nan, 0.2]\n", "must be finite"),
+        ("thresholds:\n  FollowBot: [1.1, 0.2]\n", "must be in"),
+        (
+            "thresholds:\n  FollowBot: [9.99, 0.2]\n",
+            "redaction sentinel for both values",
+        ),
+        ("thresholds:\n  TypoBot: [0.8, 0.2]\n", "not a model score head"),
+    ],
+)
+def test_invalid_threshold_tables_fail_loudly(tmp_path, policy_fragment, message):
+    m = _load_sink_module()
+    bad = tmp_path / "bad_policy.yaml"
+    bad.write_text("version: test\n" + policy_fragment)
+
+    with pytest.raises(ValueError, match=message):
+        m._load_policy(str(bad))
+
+
+def test_redacted_cusp_delta_cannot_enable_a_configured_cusp_head(tmp_path):
+    m = _load_sink_module()
+    bad = tmp_path / "bad_policy.yaml"
+    bad.write_text(
+        """\
+version: test
+cusp_delta: 9.99
+cusp_heads:
+  EngagementAmplifier: [0.8, 0.2]
+"""
+    )
+
+    with pytest.raises(ValueError, match="cusp_delta uses the redaction sentinel"):
+        m._load_policy(str(bad))
+
+
+def test_shipped_redacted_cusp_policy_cannot_match_scores():
+    m = _load_sink_module()
+    decision = m._Decision()
+
+    m._cusp_lane(
+        uid_int=1,
+        dec=decision,
+        user_labels=[],
+        scores_by_name={"EngagementAmplifier": 0.5},
+        legit=0.5,
+        total_actions_gate=m.DEFAULT_POLICY.min_actions_for_enforcement,
+        pol=m.DEFAULT_POLICY,
+        args=None,
+        r=None,
+        metrics={},
+    )
+
+    assert not decision.cusp_met
+    assert decision.cusp_head is None
+
+
+def test_configured_cusp_policy_still_matches_scores():
+    m = _load_sink_module()
+    decision = m._Decision()
+    labels = []
+    policy = dataclasses.replace(
+        m.DEFAULT_POLICY,
+        cusp_delta=0.05,
+        cusp_heads={"EngagementAmplifier": (0.5, 0.3)},
+    )
+
+    m._cusp_lane(
+        uid_int=1,
+        dec=decision,
+        user_labels=labels,
+        scores_by_name={"EngagementAmplifier": 0.5},
+        legit=0.3,
+        total_actions_gate=policy.min_actions_for_enforcement,
+        pol=policy,
+        args=SimpleNamespace(cusp_liveness_sample_per_10k=0),
+        r=None,
+        metrics={},
+    )
+
+    assert decision.cusp_met
+    assert decision.cusp_head == "EngagementAmplifier"
+    assert "EngagementAmplifier" in labels


### PR DESCRIPTION
## Summary

- document the results-sink policy pair semantics and the public 9.99 redaction sentinel
- validate policy tables, head names, numeric finiteness, ranges, and sentinel consistency at load time
- warn when a policy contains redacted fields and explicitly disable affected lanes
- add focused tests for valid, malformed, and redacted policies

## Why

The checked-in public policy uses 9.99 to represent redacted thresholds. The cusp lane previously evaluated tau - cusp_delta; with the public values, 9.99 - 9.99 becomes 0. That arithmetic meant the sentinel did not reliably keep the lane disabled.

This change gives the sentinel explicit runtime behavior instead of relying on out-of-range comparisons. It does not propose, infer, or expose production threshold values.

## Validation

- 42 passed, 3 skipped in bdsm/tests
- Ruff format check passed
- Ruff core error and import checks passed
- git diff --check passed

Addresses #25