### PR TITLE
fix: MAGA (Make Argentina Great Again)

### DIFF
--- a/home-mixer/params/param.rs
+++ b/home-mixer/params/param.rs
@@ -264,6 +264,18 @@ param!(
     true
 );
 param!(
+    EnableMagaBoost,
+    bool,
+    "rust_home_mixer_enable_maga_boost",
+    false
+);
+param!(
+    MagaBoostFactor,
+    f64,
+    "rust_home_mixer_maga_boost_factor",
+    1.15
+);
+param!(
     TopicOonWeightFactor,
     f64,
     "rust_home_mixer_topic_oon_weight_factor",

--- a/home-mixer/scorers/maga.rs
+++ b/home-mixer/scorers/maga.rs
@@ -1,0 +1,172 @@
+//! MAGA: Make Argentina Great Again.
+//!
+//! Detects posts of Argentine origin and hands `RankingScorer` a scalar
+//! multiplier for them.
+
+use crate::models::candidate::PostCandidate;
+use crate::models::query::ScoredPostsQuery;
+use crate::params::*;
+
+/// Regional flag emoji for Argentina (U+1F1E6 U+1F1F7).
+const AR_FLAG: &str = "\u{1F1E6}\u{1F1F7}";
+
+/// Markers of Argentine origin, matched on whole words after normalization.
+/// Entries may span several words. Kept deliberately small: these are the
+/// signals that carry the most weight per token, not an exhaustive lexicon.
+///
+/// Several entries ("mate", "messi", "argentina") are ordinary words in other
+/// languages, so the list is only consulted for posts tagged as Spanish.
+const MAGA_MARKERS: &[&str] = &[
+    "che",
+    "boludo",
+    "mate",
+    "asado",
+    "milei",
+    "messi",
+    "maradona",
+    "quilombo",
+    "argentina",
+    "el mejor pais del mundo",
+];
+
+/// Lowercases, strips Spanish diacritics and collapses everything that is not
+/// alphanumeric into single spaces, so that markers can be matched on word
+/// boundaries regardless of accents or punctuation.
+fn normalize(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push(' ');
+    let mut pending_space = false;
+
+    for c in text.to_lowercase().chars() {
+        let folded = match c {
+            'á' => 'a',
+            'é' => 'e',
+            'í' => 'i',
+            'ó' => 'o',
+            'ú' | 'ü' => 'u',
+            'ñ' => 'n',
+            other => other,
+        };
+
+        if folded.is_alphanumeric() {
+            if pending_space {
+                out.push(' ');
+                pending_space = false;
+            }
+            out.push(folded);
+        } else {
+            pending_space = true;
+        }
+    }
+
+    out.push(' ');
+    out
+}
+
+/// True when `marker` occurs in `normalized` on word boundaries. `normalized`
+/// is space-padded and single-spaced, so it is enough to check that the
+/// characters surrounding a match are spaces.
+fn contains_word(normalized: &str, marker: &str) -> bool {
+    normalized.match_indices(marker).any(|(start, _)| {
+        let before = normalized.as_bytes().get(start.wrapping_sub(1));
+        let after = normalized.as_bytes().get(start + marker.len());
+        start > 0 && before == Some(&b' ') && after == Some(&b' ')
+    })
+}
+
+/// True when the post carries at least one signal of Argentine origin.
+///
+/// The flag emoji is accepted in any language; the lexical markers require the
+/// post to be tagged as Spanish.
+pub(crate) fn is_argentine(text: &str, language_code: Option<&str>) -> bool {
+    if text.contains(AR_FLAG) {
+        return true;
+    }
+
+    if !language_code.is_some_and(|code| code.eq_ignore_ascii_case("es")) {
+        return false;
+    }
+
+    let normalized = normalize(text);
+    MAGA_MARKERS
+        .iter()
+        .any(|marker| contains_word(&normalized, marker))
+}
+
+/// Scalar multiplier applied to a candidate's score, alongside author
+/// diversity and the out-of-network factor.
+///
+/// Returns 1.0 (a no-op) unless the boost is enabled and the post looks
+/// Argentine.
+pub(crate) fn maga_multiplier(query: &ScoredPostsQuery, candidate: &PostCandidate) -> f64 {
+    if !query.params.get(EnableMagaBoost) {
+        return 1.0;
+    }
+
+    if is_argentine(&candidate.tweet_text, candidate.language_code.as_deref()) {
+        query.params.get(MagaBoostFactor)
+    } else {
+        1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_word_marker_is_argentine() {
+        assert!(is_argentine("che qué quilombo se armó", Some("es")));
+        assert!(is_argentine("mañana hay asado", Some("es")));
+    }
+
+    #[test]
+    fn multi_word_marker_is_argentine() {
+        assert!(is_argentine(
+            "argenmemes: el mejor país del mundo, sin dudas",
+            Some("es")
+        ));
+    }
+
+    #[test]
+    fn markers_match_regardless_of_accents_and_punctuation() {
+        assert!(is_argentine("¡MILEI!", Some("es")));
+        assert!(is_argentine("el mejor pais del mundo", Some("es")));
+    }
+
+    #[test]
+    fn flag_emoji_is_argentine_in_any_language() {
+        assert!(is_argentine("world champions \u{1F1E6}\u{1F1F7}", Some("en")));
+        assert!(is_argentine("\u{1F1E6}\u{1F1F7}", None));
+    }
+
+    #[test]
+    fn markers_must_be_whole_words() {
+        // "che" inside "coche", "noche", "leche" must not match.
+        assert!(!is_argentine("esta noche compro leche", Some("es")));
+        // "mate" inside "matemática" must not match.
+        assert!(!is_argentine("tarea de matemática", Some("es")));
+    }
+
+    #[test]
+    fn ambiguous_markers_require_spanish() {
+        // "mate" and "messi" read as ordinary words elsewhere.
+        assert!(!is_argentine("thanks mate", Some("en")));
+        assert!(!is_argentine("Messi ist der Beste", Some("de")));
+    }
+
+    #[test]
+    fn unmarked_spanish_post_is_not_argentine() {
+        assert!(!is_argentine("después de todo, ya estás aquí", Some("es")));
+    }
+
+    #[test]
+    fn untagged_language_falls_back_to_flag_only() {
+        assert!(!is_argentine("che boludo", None));
+    }
+
+    #[test]
+    fn empty_text_is_not_argentine() {
+        assert!(!is_argentine("", Some("es")));
+    }
+}

--- a/home-mixer/scorers/mod.rs
+++ b/home-mixer/scorers/mod.rs
@@ -1,4 +1,5 @@
 pub mod author_cold_start;
+pub mod maga;
 pub mod phoenix_scorer;
 pub mod phoenix_scores_ranking_scorer;
 pub mod ranking_scorer;

--- a/home-mixer/scorers/ranking_scorer.rs
+++ b/home-mixer/scorers/ranking_scorer.rs
@@ -1,6 +1,7 @@
 use crate::models::candidate::{MpnParts, PhoenixScores, PostCandidate, SlateContext};
 use crate::models::query::ScoredPostsQuery;
 use crate::params::*;
+use crate::scorers::maga::maga_multiplier;
 use crate::scorers::author_cold_start::AuthorColdStart;
 use crate::scorers::value_model_gate::GateModel;
 use rustc_hash::FxHashMap;
@@ -783,6 +784,7 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for RankingScorer {
                     if oon_applies(c) {
                         m *= effective_oon;
                     }
+                    m *= maga_multiplier(query, c);
                     m
                 })
                 .collect();
@@ -849,11 +851,12 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for RankingScorer {
             .enumerate()
             .map(|(i, c)| {
                 let after_diversity = diversity_adjusted[i];
-                if oon_applies(c) {
+                let after_oon = if oon_applies(c) {
                     after_diversity * effective_oon
                 } else {
                     after_diversity
-                }
+                };
+                after_oon * maga_multiplier(query, c)
             })
             .collect();
 
@@ -1042,6 +1045,58 @@ mod tests {
         let oon_score = scored[1].as_ref().unwrap().score.unwrap();
 
         assert!((oon_score - in_network_score * 0.75).abs() < 1e-9);
+    }
+
+    fn spanish_candidate(author_id: u64, text: &str) -> PostCandidate {
+        PostCandidate {
+            tweet_text: text.to_string(),
+            language_code: Some("es".to_string()),
+            ..candidate(author_id, Some(true))
+        }
+    }
+
+    #[tokio::test]
+    async fn applies_maga_boost_to_argentine_posts() {
+        let scorer = test_scorer();
+        let candidates = vec![
+            spanish_candidate(1, "hoy llueve en toda la ciudad"),
+            spanish_candidate(2, "che qué quilombo se armó"),
+        ];
+
+        let query = query_with_flags(&[
+            ("rust_home_mixer_enable_maga_boost", "true"),
+            ("rust_home_mixer_maga_boost_factor", "1.15"),
+            ("rust_home_mixer_value_model_mode", "weighted"),
+            ("rust_home_mixer_enable_mpn_scoring", "false"),
+        ]);
+        let scored = scorer.score(&query, &candidates).await;
+
+        let neutral_score = scored[0].as_ref().unwrap().score.unwrap();
+        let argentine_score = scored[1].as_ref().unwrap().score.unwrap();
+
+        assert!((argentine_score - neutral_score * 1.15).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn maga_boost_disabled_is_noop() {
+        let scorer = test_scorer();
+        let candidates = vec![
+            spanish_candidate(1, "hoy llueve en toda la ciudad"),
+            spanish_candidate(2, "che qué quilombo se armó"),
+        ];
+
+        let query = query_with_flags(&[
+            ("rust_home_mixer_enable_maga_boost", "false"),
+            ("rust_home_mixer_maga_boost_factor", "1.15"),
+            ("rust_home_mixer_value_model_mode", "weighted"),
+            ("rust_home_mixer_enable_mpn_scoring", "false"),
+        ]);
+        let scored = scorer.score(&query, &candidates).await;
+
+        let neutral_score = scored[0].as_ref().unwrap().score.unwrap();
+        let argentine_score = scored[1].as_ref().unwrap().score.unwrap();
+
+        assert!((argentine_score - neutral_score).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
## What

**MAGA: Make Argentina Great Again.**

Adds an optional scalar multiplier that boosts posts of Argentine origin, applied alongside the existing author-diversity and out-of-network multipliers.

Two new feature switches, **both off / no-op by default**:

- `rust_home_mixer_enable_maga_boost` (bool, default `false`)
- `rust_home_mixer_maga_boost_factor` (f64, default `1.15`)

## How

`PostCandidate` carries no author-country signal, so the boost keys off the post itself (`home-mixer/scorers/maga.rs`):

- the Argentine flag emoji, accepted in any language
- a short list of high-signal markers - `che`, `boludo`, `mate`, `asado`, `milei`, `messi`, `maradona`, `quilombo`, `argentina`, `el mejor pais del mundo` - but only for posts already tagged `language_code == "es"`

Text is normalized first: lowercased, diacritics folded, and everything non-alphanumeric collapsed to single spaces. Markers are then matched on word boundaries, which gives three properties worth calling out:

1. Substrings do not match. `che` inside `noche` / `leche` and `mate` inside `matemática` are rejected.
2. Accents and punctuation do not matter. `¡MILEI!` and `el mejor país del mundo` both match.
3. Multi-word markers work the same way as single words, so the list can hold phrases without a separate code path.

Markers that read as ordinary words elsewhere (`mate`, `messi`, `argentina`) are gated behind the Spanish tag, so "thanks mate" does not match.

Wired into `RankingScorer::score` at the point where `effective_oon` and the diversity multipliers are already combined, in both the MPN path and the weighted path, so the two stay consistent.

## Tests

- 9 unit tests on the detector in `maga.rs` (single-word and multi-word markers, accent and punctuation folding, flag-in-any-language, whole-word matching, language gating, unmarked Spanish, untagged language, empty text)
- 2 tests in `ranking_scorer.rs`: boost applies at the configured factor with the switch on, and is an exact no-op with it off

