### PR TITLE
Fix Brazil election filter excluding a listed viewer's own id

### DIFF
--- a/home-mixer/filters/brazil_2026_election_filter.rs
+++ b/home-mixer/filters/brazil_2026_election_filter.rs
@@ -1383,12 +1383,16 @@ impl Filter<ScoredPostsQuery, PostCandidate> for Brazil2026ElectionFilter {
         query: &ScoredPostsQuery,
         candidates: Vec<PostCandidate>,
     ) -> FilterResult<PostCandidate> {
-        let followed_user_ids: FxHashSet<u64> = query
+        let mut followed_user_ids: FxHashSet<u64> = query
             .user_features
             .followed_user_ids
             .iter()
             .map(|&id| id as u64)
             .collect();
+        // followed_user_ids never includes the viewer. Treat self as allowed so a
+        // listed viewer's own id is not excluded when it appears as retweeted /
+        // quoted / ancestor (SelfReplyChainFilter uses the same insert).
+        followed_user_ids.insert(query.user_id);
 
         let (removed, kept): (Vec<_>, Vec<_>) = candidates
             .into_iter()
@@ -1401,6 +1405,7 @@ impl Filter<ScoredPostsQuery, PostCandidate> for Brazil2026ElectionFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::user_features::UserFeatures;
 
     /// Stable sample ids from the set (sorted source list order).
     const SAMPLE_LISTED: [u64; 4] = [14160928, 14492205, 15022409, 20242549];
@@ -1409,6 +1414,17 @@ mod tests {
         PostCandidate {
             tweet_id,
             author_id,
+            ..Default::default()
+        }
+    }
+
+    fn query_with_follows(viewer_id: u64, followed: Vec<i64>) -> ScoredPostsQuery {
+        ScoredPostsQuery {
+            user_id: viewer_id,
+            user_features: UserFeatures {
+                followed_user_ids: followed,
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -1569,5 +1585,85 @@ mod tests {
                 &no_follows
             ));
         }
+    }
+
+    #[test]
+    fn keeps_listed_author_the_viewer_follows() {
+        let filter = Brazil2026ElectionFilter;
+        let listed = SAMPLE_LISTED[0];
+        let query = query_with_follows(99, vec![listed as i64]);
+        let candidates = vec![
+            make_candidate(1, 1),
+            make_candidate(2, listed),
+            make_candidate(3, SAMPLE_LISTED[1]),
+        ];
+
+        let result = filter.filter(&query, candidates);
+
+        assert_eq!(
+            result.kept.iter().map(|c| c.tweet_id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].author_id, SAMPLE_LISTED[1]);
+    }
+
+    #[test]
+    fn keeps_retweet_quote_and_ancestor_when_listed_id_is_viewer() {
+        let filter = Brazil2026ElectionFilter;
+        let listed = SAMPLE_LISTED[0];
+        let query = query_with_follows(listed, vec![]);
+
+        let mut retweet = make_candidate(10, 999);
+        retweet.retweeted_user_id = Some(listed);
+        let mut quote = make_candidate(20, 888);
+        quote.quoted_user_id = Some(listed);
+        let mut reply = make_candidate(30, 777);
+        reply.in_reply_to_tweet_id = Some(29);
+        reply.ancestors = vec![29];
+        reply.ancestor_users = vec![listed];
+
+        let result = filter.filter(&query, vec![retweet, quote, reply]);
+
+        assert_eq!(result.kept.len(), 3);
+        assert!(result.removed.is_empty());
+    }
+
+    #[test]
+    fn still_drops_unfollowed_listed_retweet_quote_and_ancestor() {
+        let filter = Brazil2026ElectionFilter;
+        let listed = SAMPLE_LISTED[1];
+        let query = query_with_follows(99, vec![]);
+
+        let mut retweet = make_candidate(10, 999);
+        retweet.retweeted_user_id = Some(listed);
+        let mut quote = make_candidate(20, 888);
+        quote.quoted_user_id = Some(listed);
+        let mut reply = make_candidate(30, 777);
+        reply.in_reply_to_tweet_id = Some(29);
+        reply.ancestors = vec![29];
+        reply.ancestor_users = vec![listed];
+
+        let result = filter.filter(&query, vec![retweet, quote, reply]);
+
+        assert!(result.kept.is_empty());
+        assert_eq!(result.removed.len(), 3);
+    }
+
+    #[test]
+    fn keeps_reply_when_viewer_follows_listed_ancestor() {
+        let filter = Brazil2026ElectionFilter;
+        let listed = SAMPLE_LISTED[3];
+        let query = query_with_follows(99, vec![listed as i64]);
+        let mut reply = make_candidate(30, 777);
+        reply.in_reply_to_tweet_id = Some(29);
+        reply.ancestors = vec![29, 28];
+        reply.ancestor_users = vec![listed, 42];
+
+        let result = filter.filter(&query, vec![reply]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 30);
+        assert!(result.removed.is_empty());
     }
 }


### PR DESCRIPTION
## Bug

`Brazil2026ElectionFilter` treats a user as excluded when they are on the Electoral Court list **and** not in `query.user_features.followed_user_ids`.

That follow set is the social-graph following list. It never contains the viewer. So if the viewer is themselves a listed account, their own id is excluded.

That drops For You candidates that only surface the viewer:

- someone else retweets the viewer (`retweeted_user_id == query.user_id`)
- someone else quotes the viewer (`quoted_user_id == query.user_id`)
- a reply whose `ancestor_users` includes the viewer

`SelfTweetFilter` already removes the viewer's own posts. This hole is the amplification / thread-context path.

`SelfReplyChainFilter` already inserts `query.user_id` into its allowed set for the same reason. This filter did not.

Existing tests used `ScoredPostsQuery::default()` (empty follows, `user_id == 0`) and never covered the follower exception or self-id.

## Fix

Insert `query.user_id` into the allowed set before `should_remove`.

`is_excluded_author` is unchanged: listed **and** `!followed_user_ids.contains`. Unfollowed listed authors, retweets, quotes, and ancestors still drop.

## Tests

- listed author the viewer follows is kept; a different unfollowed listed author still drops
- retweet / quote / listed ancestor of the **viewer** are kept
- the same three shapes still drop when the listed id is not the viewer and is not followed
- reply is kept when the viewer follows the listed ancestor

Lane: `home-mixer/filters/brazil_2026_election_filter.rs` only. Based on `xai-org/x-algorithm` main (`c65aa179`).