### PR TITLE
Validate BotMaker collection function inputs

### DIFF
--- a/botmaker/src/java/com/twitter/botmaker/function/collection/First.java
+++ b/botmaker/src/java/com/twitter/botmaker/function/collection/First.java
@@ -18,7 +18,7 @@ import com.twitter.botmaker.runtime.Runtime;
     arguments = {"the list"},
     returnType = "T",
     deprecated = false,
-    description = "The First element of the list",
+    description = "Returns the first element of a non-empty list.",
     actionLevel = ActionLevel.NO_ACTION,
     examples = {
         "First(List(1))"
@@ -46,6 +46,9 @@ public class First extends FunctionNode1<Runtime, List<Object>> {
 
   @Override
   public Object apply(Context<Runtime> context, List<Object> list) {
+    if (list.isEmpty()) {
+      throw new IllegalArgumentException("First() requires a non-empty list");
+    }
     return list.get(0);
   }
 }

--- a/botmaker/src/java/com/twitter/botmaker/function/collection/FirstN.java
+++ b/botmaker/src/java/com/twitter/botmaker/function/collection/FirstN.java
@@ -24,7 +24,10 @@ import com.twitter.botmaker.runtime.Runtime;
     },
     returnType = "List<T>",
     deprecated = false,
-    description = "Returns the first n values of the list. if n > len(list) return list.",
+    description =
+        "Returns the first n values of the list."
+            + " Returns an empty list if n is negative."
+            + " Returns the whole list if n is greater than the length of the list.",
     actionLevel = ActionLevel.NO_ACTION,
     examples = {
         "FirstN(List(\"asdf\", \"bas\", \"biz\"), 2)"
@@ -54,6 +57,7 @@ public class FirstN extends FunctionNode2<Runtime, List<Object>, Long> {
 
   @Override
   public Object apply(Context<Runtime> context, List<Object> list, Long n) {
-    return list.subList(0, Math.min(n.intValue(), list.size()));
+    long itemCount = Math.max(0L, Math.min(n.longValue(), (long) list.size()));
+    return list.subList(0, (int) itemCount);
   }
 }

--- a/botmaker/src/java/com/twitter/botmaker/function/collection/Slice.java
+++ b/botmaker/src/java/com/twitter/botmaker/function/collection/Slice.java
@@ -28,7 +28,9 @@ import com.twitter.botmaker.runtime.Runtime;
     },
     name = {"Slice", "Substring"},
     returnType = "String",
-    description = "Returns a substring or a sublist",
+    description =
+        "Returns a substring or a sublist."
+            + " Throws an exception if the requested range is invalid.",
     actionLevel = ActionLevel.NO_ACTION,
     examples = {
         "Slice(\"teststringteststring\", 1)",
@@ -74,10 +76,14 @@ public class Slice extends FunctionNode2O1<Runtime, Object, Long, Long> {
   protected Object apply(
       Context<Runtime> context, Object input, Long beginIndex, Long endIndex) {
     if (input instanceof String) {
-      return ((String) input).substring(beginIndex.intValue(), endIndex.intValue());
+      String string = (String) input;
+      validateRange(beginIndex, endIndex, string.length());
+      return string.substring(beginIndex.intValue(), endIndex.intValue());
     } else if (input instanceof List) {
+      List list = (List) input;
+      validateRange(beginIndex, endIndex, list.size());
       return Collections.unmodifiableList(new ArrayList<>(
-          ((List) input).subList(beginIndex.intValue(), endIndex.intValue())));
+          list.subList(beginIndex.intValue(), endIndex.intValue())));
     } else {
       throw new IllegalArgumentException(mkErrorMessage(input.getClass()));
     }
@@ -93,6 +99,16 @@ public class Slice extends FunctionNode2O1<Runtime, Object, Long, Long> {
       return apply(context, list, beginIndex, Long.valueOf(list.size()));
     } else {
       throw new IllegalArgumentException(mkErrorMessage(input.getClass()));
+    }
+  }
+
+  private static void validateRange(Long beginIndex, Long endIndex, int inputLength) {
+    if (beginIndex < 0 || endIndex < beginIndex || endIndex > inputLength) {
+      throw new IllegalArgumentException(String.format(
+          "invalid Slice() range [%d, %d) for input of length %d",
+          beginIndex,
+          endIndex,
+          inputLength));
     }
   }
 


### PR DESCRIPTION
## Summary

- Reject an empty list in `First()` with a clear `IllegalArgumentException`.
- Clamp the `FirstN()` count to the valid range from zero through the list size.
- Validate every `Slice()` range before calling `substring()` or `subList()`.
- Document the new boundary behavior in each function definition.

## Problem

The collection functions passed unchecked values to Java APIs. This exposed implementation exceptions such as `IndexOutOfBoundsException` and `IllegalArgumentException` without BotMaker-specific context. `FirstN()` also converted a `Long` to an `int` before it applied bounds. Large values could therefore wrap before validation.

## Solution

`First()` now detects an empty list before it reads index zero. It reports that the function requires a non-empty list.

`FirstN()` now clamps the requested count while it is still a `long`. A negative count returns an empty view. A count greater than the list size returns the full list. This also handles `Long.MIN_VALUE` and `Long.MAX_VALUE` without integer wraparound.

`Slice()` now checks that the start index is non-negative, the end index is not less than the start index, and the end index does not exceed the input length. The check runs before either index is converted to an `int`. Invalid string and list ranges now produce the same error format with the requested range and input length.

## Validation

- Ran `git diff --check`.
- Ran direct Java boundary checks for negative, zero, in-range, oversized, `Long.MIN_VALUE`, and `Long.MAX_VALUE` counts.
- Ran direct Java boundary checks for negative bounds, reversed bounds, oversized bounds, empty ranges, and valid ranges.

The public repository snapshot does not include a root build workspace or an externally resolvable BotMaker dependency graph. A complete BotMaker target build is therefore not available from this checkout.

Fixes #58
