### PR TITLE
Scope Brazil2026ElectionFilter to viewers in Brazil

### DIFF
--- a/home-mixer/filters/brazil_2026_election_filter.rs
+++ b/home-mixer/filters/brazil_2026_election_filter.rs
@@ -17,6 +17,9 @@ use xai_candidate_pipeline::filter::{Filter, FilterResult};
 
 // OmarAzizSenador deleted his account at the time this code was written.
 
+/// Viewer country code the Electoral Court order applies to.
+const BRAZIL_COUNTRY_CODE: &str = "br";
+
 /// User ids reported to the Electoral Court for the Brazil 2026 election.
 static BRAZIL_2026_ELECTION_USER_IDS: LazyLock<FxHashSet<u64>> = LazyLock::new(|| {
     FxHashSet::from_iter([
@@ -1378,6 +1381,13 @@ impl Brazil2026ElectionFilter {
 }
 
 impl Filter<ScoredPostsQuery, PostCandidate> for Brazil2026ElectionFilter {
+    /// The Electoral Court order applies to viewers in Brazil, so scope the
+    /// filter to them. Without this the filter runs for every viewer in every
+    /// country, which is broader than the order requires.
+    fn enable(&self, query: &ScoredPostsQuery) -> bool {
+        query.country_code.eq_ignore_ascii_case(BRAZIL_COUNTRY_CODE)
+    }
+
     fn filter(
         &self,
         query: &ScoredPostsQuery,
@@ -1569,5 +1579,37 @@ mod tests {
                 &no_follows
             ));
         }
+    }
+
+    fn query_from_country(country_code: &str) -> ScoredPostsQuery {
+        ScoredPostsQuery {
+            country_code: country_code.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn enabled_for_viewers_in_brazil() {
+        assert!(Brazil2026ElectionFilter.enable(&query_from_country("br")));
+    }
+
+    #[test]
+    fn enabled_regardless_of_country_code_case() {
+        assert!(Brazil2026ElectionFilter.enable(&query_from_country("BR")));
+    }
+
+    #[test]
+    fn disabled_for_viewers_outside_brazil() {
+        for country_code in ["us", "gb", "jp", "pt"] {
+            assert!(
+                !Brazil2026ElectionFilter.enable(&query_from_country(country_code)),
+                "expected filter to be disabled for {country_code}"
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_when_country_code_is_unknown() {
+        assert!(!Brazil2026ElectionFilter.enable(&ScoredPostsQuery::default()));
     }
 }


### PR DESCRIPTION
`Brazil2026ElectionFilter` never reads the viewer's country, so as written it applies to every For You request in every country rather than to the viewers the Electoral Court order covers.

### Evidence

`should_remove` takes only the candidate and the viewer's follow list ([filter L1363](https://github.com/xai-org/x-algorithm/blob/c65aa17/home-mixer/filters/brazil_2026_election_filter.rs#L1363)), and the filter is added to the pre-scoring chain unconditionally ([pipeline L368](https://github.com/xai-org/x-algorithm/blob/c65aa17/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs#L368)).

Both mechanisms needed to scope it already exist and are unused:

- `ScoredPostsQuery` carries `country_code` ([query.rs L46](https://github.com/xai-org/x-algorithm/blob/c65aa17/home-mixer/models/query.rs#L46))
- `Filter::enable(&self, query)` gates a filter per request ([filter.rs L21](https://github.com/xai-org/x-algorithm/blob/c65aa17/candidate-pipeline/filter.rs#L21)) and is honoured by the pipeline ([candidate_pipeline.rs L352](https://github.com/xai-org/x-algorithm/blob/c65aa17/candidate-pipeline/candidate_pipeline.rs#L352))

Eight other filters in the same chain already use `enable()` for exactly this: `VideoFilter`, `TopicIdsFilter`, `NewUserMinEngagementFilter`, `InventoryHoldoutFilter` and others.

There is also a layering signal. Every other jurisdiction-scoped rule in the repo lives in `visibility-filtering` and checks viewer country. No filter in `home-mixer/filters/` reads viewer country at all, so this is the only geo-scoped rule in a service with no geo-scoping convention.

### Change

Adds an `enable()` override gating the filter on `country_code == "br"`, case-insensitively.

Unknown or empty country codes leave the filter **disabled**, which matches the existing convention for legal withholding: `viewer_in_withheld_country` in `visibility-filtering/rules/tes_rules.rs` returns `false` when the viewer country is not known. Happy to invert that to fail-closed if you would rather over-apply than under-apply on unknown geo.

Adds four tests. Existing tests call `filter()` directly and are unaffected.

### If this is intentional

Applying globally does guarantee compliance regardless of geolocation accuracy, which matters with VPNs and travel. If that is the reasoning, please close this, though a comment recording the decision might be worth adding, since the surrounding conventions read the other way.

### Caveat

`home-mixer` ships no `Cargo.toml`, so I could not compile or run the tests. The file is `rustfmt --check` clean under edition 2021. Verification of the change is on you.