### PR TITLE
Declare Rust MSRV and warn against distro-packaged toolchains

### DIFF
--- a/phoenix/Cargo.toml
+++ b/phoenix/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.85"
 
 [workspace.dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/phoenix/README.md
+++ b/phoenix/README.md
@@ -310,8 +310,12 @@ apt update && apt install build-essential cmake pkg-config unzip \
 ```
 
 Then install [uv](https://docs.astral.sh/uv/getting-started/installation/), a
-Rust toolchain (<https://rustup.rs>) and `protoc` >= 3.15 (the protos use
-proto3 `optional`, which older `protoc` rejects — Ubuntu 22.04's
+Rust toolchain (<https://rustup.rs>) — this workspace uses the 2024 edition,
+which needs rustc **1.85 or newer**; your distribution's packaged `rustc`/
+`cargo` is very likely too old (Ubuntu 24.04 ships 1.75) and will fail with a
+confusing `feature edition2024 is required` error rather than a clear version
+message, so install via rustup rather than `apt` — and `protoc` >= 3.15 (the
+protos use proto3 `optional`, which older `protoc` rejects — Ubuntu 22.04's
 `protobuf-compiler` is 3.12, too old). Install the official release binary
 once to a system path:
 


### PR DESCRIPTION
## Summary
- Declare `rust-version = "1.85"` under `[workspace.package]`, matching
  the edition 2024 requirement already declared there
- State the 1.85+ minimum explicitly in the prerequisites section, next
  to the existing protoc-version rationale
- Warn against distro-packaged Rust toolchains, which are commonly older
  than edition 2024 requires

## Problem
The workspace sets `edition = "2024"` (requires rustc >=1.85) but no
Cargo.toml declares `rust-version`, and no doc states a minimum. Installing
via a Linux distribution's package manager -- a natural reading of "install
a Rust toolchain," and what many CI base images ship by default -- commonly
gives a too-old toolchain. On Ubuntu 24.04 (rustc 1.75.0) this fails with:

    feature `edition2024` is required
    The package requires the Cargo feature called `edition2024`, but that
    feature is not stabilized in this version of Cargo (1.75.0).

which reads like an unstable/nightly-feature problem rather than a version
mismatch.

## Fix
- Add `rust-version = "1.85"`, standard MSRV metadata that crates.io and
  MSRV-aware tooling read.
- State the requirement in prose, next to the protoc callout that already
  explains why an old version fails the same way.

## Verification
- Reproduced the failure above on a clean Ubuntu 24.04 container with
  `apt install rustc cargo`.
- Confirmed no Cargo.toml in the repo declared `rust-version` and no doc
  mentioned a minimum version, via grep across `**/*.md` and
  `**/Cargo.toml`.

A toolchain old enough to reject `edition2024` outright (1.75.0, tested
above) fails at manifest-parse time, before `rust-version` is checked, so
this doesn't change that specific error message -- it's correct, standard
metadata regardless, and should produce a clean version error on
toolchains between "supports rust-version" and "supports edition2024." The
doc change is the part verified to fix the reported symptom directly.