### PR TITLE
Fix panic on empty user_ids in RetrieveTopKCandidatesRequest

### DIFF
--- a/phoenix/crates/serving/xai-recsys-engine/src/python.rs
+++ b/phoenix/crates/serving/xai-recsys-engine/src/python.rs
@@ -2824,7 +2824,14 @@ impl RecsysRetrievalPredictorImpl {
             })?;
         let _in_flight_guard = InFlightGuard::new();
 
-        let user_id = request.user_ids.pop().unwrap();
+        let Some(user_id) = request.user_ids.pop() else {
+            NUM_REQUESTS_REJECTED
+                .with_label_values(&["invalid_argument", client.as_str()])
+                .inc();
+            return Err(Status::invalid_argument(
+                "RetrieveTopKCandidatesRequest.user_ids must not be empty",
+            ));
+        };
         let sequence = request.sequences.pop();
         let topic_entity_ids = request.topic_entity_ids;
         let topic_filter_mode = request.topic_filter_mode.unwrap_or(0);


### PR DESCRIPTION
## Summary
- Reject an empty `user_ids` in `RetrieveTopKCandidatesRequest` with a
  `Status::invalid_argument` instead of panicking
- Increment the existing `NUM_REQUESTS_REJECTED` metric on this path,
  matching the other rejection paths already in this function

## Problem
`RecsysRetrievalPredictorImpl::retrieve_top_k_candidates_inner` does:

    let user_id = request.user_ids.pop().unwrap();
    let sequence = request.sequences.pop();

`user_ids` is a protobuf `repeated` field, so nothing prevents a caller
from sending it empty. `.pop()` on an empty Vec returns None, and
`.unwrap()` panics -- this is reachable directly from an external gRPC
request, past the admission-control and deadline-shedding checks earlier
in the same function. Any caller sending a request with no user IDs can
take down this handler.

The line right below handles the identically-shaped `sequences` field
correctly (kept as an Option), and `columnar_sequences` two lines further
down does the same with a `.filter(...)` chain -- this looks like an
isolated gap rather than an intentional invariant.

## Fix
`user_ids.pop()` is now matched as an Option. An empty list returns
`Status::invalid_argument` and increments `NUM_REQUESTS_REJECTED` with the
same label pattern already used three times earlier in this function,
instead of panicking.

## Verification
- Manually traced all `Status`-returning branches in this function for
  label/style consistency.
- Could not run the crate's test suite locally (workspace requires
  rustc >=1.85; see the companion MSRV PR) -- please run
  `cargo test -p xai-recsys-engine` before merging.

No existing harness for constructing `RetrieveTopKCandidatesRequest` test
fixtures was found in this crate. Didn't add one as part of this fix
rather than invent test infrastructure the change doesn't otherwise need
-- happy to add a regression test if there's an existing pattern for this
maintainers would prefer.