### PR TITLE
Add CI for phoenix/ (Python tests + Rust workspace check)

### DIFF
--- a/.github/workflows/phoenix-ci.yml
+++ b/.github/workflows/phoenix-ci.yml
@@ -1,0 +1,87 @@
+name: Phoenix CI
+
+# Scoped to phoenix/ only: it's the one component in this repo documented and
+# designed to build and run outside X's internal infrastructure (see
+# phoenix/README.md, "What's not in this repo"). Other services import
+# internal-only packages and have no standalone build manifest, so they
+# aren't included here.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "phoenix/**"
+      - ".github/workflows/phoenix-ci.yml"
+  pull_request:
+    paths:
+      - "phoenix/**"
+      - ".github/workflows/phoenix-ci.yml"
+
+defaults:
+  run:
+    working-directory: phoenix
+
+jobs:
+  python-tests:
+    name: Python tests (xrex)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.11"
+
+      # Base deps only (no --extra engine): the engine extra needs a Rust
+      # toolchain to build xai-recsys-engine via maturin, which the
+      # rust-check job below covers. Keeping this job to the pure-Python
+      # surface keeps it fast and independent of the Rust build.
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest -v
+
+  rust-check:
+    name: Rust check (crates/)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned to the workspace's documented minimum (see
+      # phoenix/Cargo.toml's rust-version and the README prerequisites) so
+      # this job actually verifies the MSRV, not just "whatever ships on the
+      # runner today."
+      - name: Install Rust 1.85.0
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            phoenix/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('phoenix/Cargo.lock') }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake pkg-config unzip \
+            libibverbs-dev libnl-3-dev libnl-route-3-dev libclang-dev libnuma-dev
+
+      # Matches phoenix/README.md's protoc guidance (>=3.15 for proto3
+      # `optional` support), using the x86_64 build to match this runner --
+      # see the corresponding fix to the README's copy-pasteable command.
+      - name: Install protoc
+        run: |
+          curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local 'bin/*' 'include/*'
+          protoc --version
+
+      - name: cargo check (workspace)
+        run: cargo check --workspace --all-targets
+
+      - name: cargo test (workspace)
+        run: cargo test --workspace


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow scoped to `phoenix/`, the one component
  documented as buildable outside X's internal infrastructure
- `python-tests`: `uv sync --group dev` + `pytest` over xrex
- `rust-check`: installs the workspace's declared MSRV, the documented
  system packages, and protoc, then `cargo check --workspace --all-targets`
  and `cargo test --workspace`

## Problem
No GitHub Actions workflow exists anywhere in this repository. Every
currently open PR is relying entirely on manual review with no automated
signal.

## Fix
A minimal, two-job workflow triggered on changes under `phoenix/`:
- `python-tests` runs the pure-Python surface only (no Rust toolchain
  required), keeping it fast and independent of the Rust build.
- `rust-check` pins rustc 1.85 explicitly (this workspace's declared
  minimum, not whatever the runner ships today) and installs the same
  system packages and protoc version documented in the README.

`home-mixer` and the other services are intentionally excluded: none of
them has a standalone Cargo.toml or build manifest in this repository, and
they import internal-only packages, so there's nothing yet for a public
runner to build. `cargo fmt --check` and `clippy` are also deliberately
excluded from this PR -- unclear whether existing code is clean against
either, and a first CI PR shouldn't open red against pre-existing code;
both are reasonable fast-follows once this is green.

## Verification
- YAML validated with `python -c "import yaml; yaml.safe_load(open(...))"`.
- `python-tests` commands run end to end: `uv sync --group dev && uv run
  pytest` passes 17/17 against the suite added in the companion tests PR.
- `rust-check` could not be run locally (no rustc >=1.85 reachable in this
  environment); the system-package list and protoc invocation are copied
  from what's already verified working in phoenix/README.md's own
  instructions, corrected to linux-x86_64 for this runner's architecture.

Please confirm the `rust-check` job goes green before merging, or flag
from CI logs if it doesn't -- happy to iterate.