### PR TITLE
Move hold_cluster_spam below act_cluster_spam_* rules to fix shadowin…

### DIFF
--- a/abuse-enforcement-service/service-lib/rules/enforcement_user.yaml
+++ b/abuse-enforcement-service/service-lib/rules/enforcement_user.yaml
@@ -174,13 +174,7 @@ rules:
     then:
       kind: act_add_labels_v2
       labels: ["SpamHighRecall"]
-      ttl_msec: 2592000000   
-
-  - id: hold_cluster_spam
-    when: 'score.model_version.startsWith("cluster_spam")'
-    then:
-      kind: skip
-      reason: cluster_spam_held
+      ttl_msec: 2592000000
 
   - id: act_cluster_spam_suspend
     when: 'score.model_version.startsWith("cluster_spam") && "cluster_spam_suspend" in score.labels'
@@ -199,7 +193,13 @@ rules:
     then:
       kind: act_add_labels_v2
       labels: ["SpamHighRecall"]
-      ttl_msec: 2592000000   
+      ttl_msec: 2592000000
+
+  - id: hold_cluster_spam
+    when: 'score.model_version.startsWith("cluster_spam")'
+    then:
+      kind: skip
+      reason: cluster_spam_held
 
   - id: act_suspend
     when: "true"


### PR DESCRIPTION
Fixes #67

The rules engine is first-match-wins, and hold_cluster_spam (a broad skip on startsWith("cluster_spam")) was ordered above the three act_cluster_spam_* action rules that share its prefix, making suspend/bounce/label unreachable for base cluster_spam decisions.

This moves hold_cluster_spam below the three action rules so it acts as the catch-all for decisions with no actionable label, mirroring how the cluster_spam_extended family is already ordered.

Note: the file header says it's mirrored from a GrowthBook dynamic config, so the live config may differ but this makes the published rules internally consistent either way. Happy to add a test for the ordering with some guidance on where the rule-evaluation tests live.