### PR TITLE
Compute cold-start boost target after MoE suppression

### DIFF
--- a/home-mixer/scorers/author_cold_start.rs
+++ b/home-mixer/scorers/author_cold_start.rs
@@ -365,7 +365,7 @@ impl AuthorColdStart {
         let arm = params.arm;
 
         let mut effective = apply_moe_ranking_policy(arm, candidates, &corpus, scores);
-        if let Some(target) = cold_start_target(&params, scores) {
+        if let Some(target) = cold_start_target(&params, &effective) {
             effective = apply_cold_start(&params, candidates, &effective, &corpus, target);
         }
         effective
@@ -695,6 +695,27 @@ rust_home_mixer:
 
         let result = author_cold_start.apply(&query, &candidates, &[10.0, 40.0, 30.0, 20.0]);
         assert_eq!(result, vec![10.0, 40.0, 30.0, 20.0]);
+    }
+
+    #[test]
+    fn cold_start_target_skips_scores_zeroed_by_moe_policy() {
+        let author_cold_start = cold_start_with_arms(vec![], vec![]);
+        let candidates = vec![
+            cold_start_candidate(1, minutes(10), 3),
+            moe_candidate(2, minutes(10), 3),
+            cold_start_candidate(3, minutes(10), 5000),
+            cold_start_candidate(4, minutes(10), 5000),
+            cold_start_candidate(5, minutes(10), 5000),
+        ];
+
+        let mut query = codivert_query(false, false);
+        let mut results = query.params.0.expect("params set");
+        results.override_fs("rust_home_mixer_cold_start_slot_min".to_string(), "2");
+        results.override_fs("rust_home_mixer_cold_start_slot_max".to_string(), "3");
+        query.params = results.into();
+
+        let result = author_cold_start.apply(&query, &candidates, &[10.0, 100.0, 90.0, 80.0, 70.0]);
+        assert_eq!(result, vec![70.0, 0.0, 90.0, 80.0, 70.0]);
     }
 
     #[test]


### PR DESCRIPTION
`AuthorColdStart::apply` zeroes suppressed Phoenix MoE candidates into `effective`, then takes the boost target from `cold_start_target(query, scores)`, the pre-suppression vector. With the shipped `cold_start_slot_min`/`cold_start_slot_max` of 15/16 the target is `ranked[15]`. For a holdout viewer every MoE candidate is zeroed, so that slot belongs to a post which will not be served and the cold-started post is boosted above the band. `apply_cold_start` already derives `positions` and `max_cold_start_slot` from `effective`, so the two halves of one decision were reading different vectors. Every existing test sets `slot_max` to 1, which makes the target the global maximum and hides the difference.

home-mixer has no Cargo.toml in this tree, so I transcribed `positions_among_nonzero`, `apply_moe_ranking_policy` and `cold_start_target` into a standalone binary with the shipped defaults: 40 candidates, a quarter of them MoE, scores from 100.0 stepping down by 2.5. The target comes out 62.5 against 50.0 for the score actually at served slot 15, landing the post at served rank 11. The added test is the same arithmetic on five candidates and returns 80.0 before the change, 70.0 after.
