### PR TITLE
phoenix: update Cargo.lock for log and rayon

### DIFF
--- a/phoenix/Cargo.lock
+++ b/phoenix/Cargo.lock
@@ -5113,6 +5113,7 @@ dependencies = [
  "crc32fast",
  "half",
  "lazy_static",
+ "log",
  "prometheus 0.14.0",
  "xai-recsys-proto",
 ]
@@ -5199,6 +5200,7 @@ dependencies = [
  "parquet",
  "prometheus 0.14.0",
  "pyo3",
+ "rayon",
  "tempfile",
  "thrift",
  "tokio",


### PR DESCRIPTION
`cargo check --locked` fails in `phoenix/`:

```
error: cannot update the lock file phoenix/Cargo.lock because --locked was passed to prevent this
```

The lockfile is missing the `log` dependency of `xai-recsys` and the `rayon` dependency of `xai-recsys-engine`. Both are declared in the crate manifests. This adds the two entries; no versions change.

Checked with `cargo check --locked --workspace` on rustc 1.94.
