### PR TITLE
Stop TES core-data misses from clearing retweet and reply ids

### DIFF
--- a/home-mixer/candidate_hydrators/core_data_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/core_data_candidate_hydrator.rs
@@ -125,6 +125,8 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for CoreDataCandidateHydrat
                 }
                 Some(Ok(None)) | None => {
                     missing_count += 1;
+                    // Ok(default) so CachedHydrator can negative-cache the miss.
+                    // update() must not apply this payload — it would wipe Thunder/Phoenix ids.
                     hydrated_candidates.push(Ok(PostCandidate::default()));
                 }
                 Some(Err(err)) => {
@@ -139,6 +141,11 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for CoreDataCandidateHydrat
     }
 
     fn update(&self, candidate: &mut PostCandidate, hydrated: PostCandidate) {
+        // TES miss is cached as Default. Applying it would clear source-populated
+        // retweet/reply ids. A real TES hit always carries author_id.
+        if is_tes_miss_payload(&hydrated) {
+            return;
+        }
         if candidate.author_id == 0 && hydrated.author_id != 0 {
             candidate.author_id = hydrated.author_id;
         }
@@ -148,6 +155,15 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for CoreDataCandidateHydrat
         candidate.ancestor_users = hydrated.ancestor_users;
         candidate.tweet_text = hydrated.tweet_text;
     }
+}
+
+fn is_tes_miss_payload(hydrated: &PostCandidate) -> bool {
+    hydrated.author_id == 0
+        && hydrated.tweet_text.is_empty()
+        && hydrated.retweeted_tweet_id.is_none()
+        && hydrated.retweeted_user_id.is_none()
+        && hydrated.in_reply_to_tweet_id.is_none()
+        && hydrated.ancestor_users.is_empty()
 }
 
 fn core_data_fetch_ids(candidates: &[PostCandidate]) -> Vec<u64> {
@@ -197,5 +213,81 @@ impl CoreDataCandidateHydrator {
             receiver.incr(metric_name.as_str(), &FOUND_SCOPE, hydrated_count as u64);
             receiver.incr(metric_name.as_str(), &MISSING_SCOPE, missing_count as u64);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clients::tweet_entity_service_client::{MockTESClient, TESClient};
+    use std::sync::Arc;
+    use xai_candidate_pipeline::hydrator::Hydrator;
+
+    fn thunder_retweet() -> PostCandidate {
+        PostCandidate {
+            tweet_id: 10,
+            author_id: 100,
+            retweeted_tweet_id: Some(99),
+            retweeted_user_id: Some(200),
+            in_reply_to_tweet_id: Some(50),
+            tweet_text: String::new(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn tes_miss_payload_does_not_clear_source_graph_ids() {
+        let hydrator = CoreDataCandidateHydrator::new(Arc::new(MockTESClient::default())
+            as Arc<dyn TESClient + Send + Sync>)
+        .await;
+        let mut candidate = thunder_retweet();
+        Hydrator::update(&hydrator, &mut candidate, PostCandidate::default());
+        assert_eq!(candidate.retweeted_tweet_id, Some(99));
+        assert_eq!(candidate.retweeted_user_id, Some(200));
+        assert_eq!(candidate.in_reply_to_tweet_id, Some(50));
+        assert_eq!(candidate.author_id, 100);
+    }
+
+    #[tokio::test]
+    async fn tes_success_fills_and_can_clear_graph_fields() {
+        let hydrator = CoreDataCandidateHydrator::new(Arc::new(MockTESClient::default())
+            as Arc<dyn TESClient + Send + Sync>)
+        .await;
+        let mut candidate = thunder_retweet();
+        Hydrator::update(
+            &hydrator,
+            &mut candidate,
+            PostCandidate {
+                author_id: 7,
+                retweeted_tweet_id: None,
+                retweeted_user_id: None,
+                in_reply_to_tweet_id: None,
+                tweet_text: "original".to_string(),
+                ancestor_users: vec![],
+                ..Default::default()
+            },
+        );
+        assert_eq!(candidate.author_id, 100);
+        assert_eq!(candidate.retweeted_tweet_id, None);
+        assert_eq!(candidate.retweeted_user_id, None);
+        assert_eq!(candidate.in_reply_to_tweet_id, None);
+        assert_eq!(candidate.tweet_text, "original");
+    }
+
+    #[tokio::test]
+    async fn tes_miss_hydrate_leaves_thunder_retweet_ids() {
+        let hydrator = CoreDataCandidateHydrator::new(Arc::new(MockTESClient::default())
+            as Arc<dyn TESClient + Send + Sync>)
+        .await;
+        let mut candidates = vec![thunder_retweet()];
+        let hydrated = hydrator
+            .hydrate(&ScoredPostsQuery::default(), &candidates)
+            .await;
+        assert!(hydrated[0].is_ok(), "miss stays Ok so it can be negative-cached");
+        hydrator.update_all(&mut candidates, hydrated);
+        assert_eq!(candidates[0].retweeted_tweet_id, Some(99));
+        assert_eq!(candidates[0].retweeted_user_id, Some(200));
+        assert_eq!(candidates[0].in_reply_to_tweet_id, Some(50));
+        assert_eq!(candidates[0].author_id, 100);
     }
 }


### PR DESCRIPTION
## Bug

Thunder and Phoenix retrieval set `retweeted_tweet_id` / `in_reply_to_tweet_id` on the candidate before TES hydration.

`CoreDataCandidateHydrator` treats a TES miss (`Ok(None)` or a missing map entry) as `Ok(PostCandidate::default())`. CachedHydrator caches that empty payload. `update()` then assigns `None` over the source-populated ids.

`author_id` was already merge-safe (`if candidate.author_id == 0`). The graph fields were not. `CoreDataHydrationFilter` keeps the candidate because `author_id` is never cleared, so the wiped ids reach ranking. `AgeFilter` derives age from the snowflake id, not core data, so it does not drop the card either.

A TES miss is not "this is not a retweet." Downstream:

- On a TES miss, `vf_candidate_hydrator.rs` only submits the underlying post to VF when `retweeted_tweet_id.is_some()`. Wiped, that post is never visibility-filtered — bypassing `AuthorBlockViewer`, `AuthorIsSuspended`, `AuthorIsDeactivated`, `ContainNsfwMedia`, `ReportedTweet`, `TweetIsBounced` on the original. `should_drop_ancillary` skips its retweet check and `AncillaryVFFilter` keeps the candidate. The retweet card itself still reaches VF; the original does not.
- `RetweetDeduplicationFilter` keys `retweeted_tweet_id.unwrap_or(tweet_id)`, so duplicate retweets of one source post all survive
- in-network RT/reply OON rescore is skipped
- retweets become cold-start eligible
- VM ranker is fed `0` instead of the source id

## Fix

Keep the miss as `Ok(default)` so it can still be negative-cached. `update()` no-ops on that empty payload so Thunder/Phoenix ids survive. A real TES hit still assigns, including `None`, so TES remains authoritative when it says the post is not a retweet.

`is_tes_miss_payload` is a structural stand-in for provenance ("this payload came from a miss"). The hydrator trait is `Vec<Result<C, String>>`; a `CacheValue` enum would be cleaner but is a framework change. A real TES hit always carries `author_id`, so the six-way conjunction does not skip a payload that should apply.

## Tests

- Empty TES payload does not clear Thunder graph ids
- TES success can still clear them
- Hydrate-on-miss stays `Ok` (negative cache) and `update_all` leaves ids

The public export does not include a Home Mixer Cargo manifest, so `cargo test` still needs X's build environment.