### PR TITLE
Keep duplicate-reply clusters processing after per-tweet failures

### DIFF
--- a/botmaker-rules/scarecrow/bot/BBQDuplicateTextRepliesProd.bot
+++ b/botmaker-rules/scarecrow/bot/BBQDuplicateTextRepliesProd.bot
@@ -14,23 +14,36 @@ action: |
     val :prodJobName = Concat(jobName, "_prod");
     val :eligibleTweets = Filter(
       :tweetId,
-      {
-        !HasBigQuerytoBotmakerLabel(:prodJobName, ToString(:tweetId)) &&
-        !Contains(GetTweetRtfLabels(:tweetId), "COPYPASTA_SPAM") &&
-        TryOrElse(GetTweet(:tweetId).card2.name != "promo_video_convo", FALSE) &&
-        TryOrElse(GetTweet(:tweetId).card2.name != "promo_image_convo", FALSE)
-      },
+      TryOrElse(
+        {
+          !HasBigQuerytoBotmakerLabel(:prodJobName, ToString(:tweetId)) &&
+          !Contains(GetTweetRtfLabels(:tweetId), "COPYPASTA_SPAM") &&
+          TryOrElse(GetTweet(:tweetId).card2.name != "promo_video_convo", FALSE) &&
+          TryOrElse(GetTweet(:tweetId).card2.name != "promo_image_convo", FALSE)
+        },
+        {
+          IncrementStat("BBQDuplicateTextRepliesProd_eligibility_lookup_failed", 1);
+          FALSE
+        }
+      ),
       StringIdListToLongList(entityId)
     );
     val :actionableTweets = Filter(
       :tweetId,
-      {
-        val :tweetAuthor = GetTweetAuthorId(:tweetId);
-        !IsTestUser(:tweetAuthor) &&
-        !IsHighPageRankUser(:tweetAuthor) &&
-        !Contains(GetLongList(`AutoExpiringTempSkipList`), :tweetAuthor) &&
-        !IsUserGrayVerified(:tweetAuthor)
-      },
+      TryOrElse(
+        {
+          val :tweetAuthor = GetTweetAuthorId(:tweetId);
+          :tweetAuthor != -1 &&
+          !IsTestUser(:tweetAuthor) &&
+          !IsHighPageRankUser(:tweetAuthor) &&
+          !Contains(GetLongList(`AutoExpiringTempSkipList`), :tweetAuthor) &&
+          !IsUserGrayVerified(:tweetAuthor)
+        },
+        {
+          IncrementStat("BBQDuplicateTextRepliesProd_exemption_lookup_failed", 1);
+          FALSE
+        }
+      ),
       :eligibleTweets
     );
     val :unactionableTweets = SetDiff(ToSet(:eligibleTweets), ToSet(:actionableTweets));
@@ -41,15 +54,26 @@ action: |
       RateLimited(
         {
           for (:tweetId in :actionableTweets) {
-            TweetRtfApplyLabel("COPYPASTA_SPAM", :tweetId);
-            SetBigQuerytoBotmakerLabel(:prodJobName, ToString(:tweetId));
-          }
+            TryOrElse(
+              {
+                TweetRtfApplyLabel("COPYPASTA_SPAM", :tweetId);
+                SetBigQuerytoBotmakerLabel(:prodJobName, ToString(:tweetId));
+                TRUE
+              },
+              {
+                IncrementStat("BBQDuplicateTextRepliesProd_action_failed", 1);
+                FALSE
+              }
+            );
+          };
+          TRUE
         },
         :rateLimitTimePeriod,
         :rateLimitThreshold,
         jobName,
         {
           Log("BBQDuplicateTextRepliesProd_rate_limited", :actionableTweets);
+          FALSE
         }
       );
     }


### PR DESCRIPTION
Addresses #65

## Bug

The public tree already has a dedicated BotMaker rule for duplicate reply clusters from both the unigram and CJK-character jobs: `BBQDuplicateTextRepliesProd`.

That rule evaluates each tweet through `Filter` and applies `COPYPASTA_SPAM` through a `for`/`ForEach`. Both BotMaker implementations aggregate each batch with `Future.collect`. A single failed per-tweet future therefore fails the whole filter or action batch. For clusters larger than the 50-item concurrency batch, later batches are reached only through the previous batch's successful `flatMap`, so one failed member prevents all later members from being processed.

A stale or temporarily unavailable tweet, safety-label lookup failure, exemption lookup failure, or label/marker write failure can therefore suppress healthy tweets in an already-detected duplicate-reply cluster.

## Fix

- Rescue eligibility failures per tweet, exclude only the uncertain tweet, and increment a fixed counter.
- Rescue author/exemption failures per tweet, reject the existing `-1` unavailable-author sentinel, and continue with the rest of the cluster.
- Rescue each `COPYPASTA_SPAM` label plus BigQuery-to-BotMaker marker transaction independently, preserving label-before-marker ordering so a failed label is never marked complete.
- Give the two `RateLimited` branches explicit Boolean results after the per-tweet loop.

The cluster job names, event condition, `COPYPASTA_SPAM` label, exemption policy, rate limit, marker namespace, and already-labeled checks are unchanged.

## Scope

This hardens actioning for clusters that the existing unigram/CJK scheduled jobs have already produced. The scheduled BigQuery clustering query is not included in the public repository, so this PR does not claim to change text normalization or cluster formation.

## Verification

- The clean branch is one commit directly on current upstream `main` (`85ac72a1bba41f21615e3f0bca56da75970a6633`) and changes one production rule file.
- Both the upstream and patched actions parse with the repository's exact ANTLR 3 `BotMaker.g` grammar.
- A policy-preservation check confirms that the event condition and every existing literal/function call remain, with only three fixed metric names and `IncrementStat` added.
- Source-level checks confirm the published `Filter` and `ForEach` fail-fast `Future.collect` boundaries, 50-item batching, `TryOrElse` rescue behavior, and sequential label-before-marker block execution.
- A 120-member regression model proves one failure stops the baseline before later batches, while the patched per-item boundary processes every healthy member and leaves failed members unmarked.
- `git diff --check` passes.

Verification run: https://github.com/jnadeau207-collab/x-algorithm/actions/runs/33702548512

The public export does not provide a runnable Scarecrow/BotMaker semantic compilation target, so the internal rule compiler remains required before deployment.
