### PR TITLE
Expand skipped conversation ancestors before For You VF

### DIFF
--- a/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
@@ -182,3 +182,39 @@ fn should_drop_reason(reason: &FilteredReason) -> bool {
         _ => true, 
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_visibility_filtering::models::SafetyResult;
+
+    fn drop_reason() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            action: Action::Drop(Default::default()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn skipped_conversation_ancestor_does_not_drop_until_gap_expanded() {
+        let drop = drop_reason();
+        let vf_results = HashMap::from([(
+            15u64,
+            Ok(Some(drop.clone())) as Result<Option<FilteredReason>>,
+        )]);
+
+        let thunder_only = PostCandidate {
+            tweet_id: 30,
+            ancestors: vec![20, 10],
+            ..Default::default()
+        };
+        assert!(!should_drop_ancillary(&thunder_only, &vf_results));
+
+        let expanded = PostCandidate {
+            tweet_id: 30,
+            ancestors: vec![20, 15, 10],
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(&expanded, &vf_results));
+    }
+}

--- a/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
+++ b/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
@@ -2,6 +2,7 @@ use crate::candidate_hydrators::ads_brand_safety_vf_hydrator::AdsBrandSafetyVfHy
 use crate::candidate_hydrators::ai_trend_feedback_context_hydrator::AiTrendFeedbackContextHydrator;
 use crate::candidate_hydrators::bidirectional_follow_hydrator::BidirectionalFollowHydrator;
 use crate::candidate_hydrators::blocked_by_hydrator::BlockedByHydrator;
+use crate::candidate_hydrators::conversation_gap_ancestor_hydrator::ConversationGapAncestorHydrator;
 use crate::candidate_hydrators::core_data_candidate_hydrator::CoreDataCandidateHydrator;
 use crate::candidate_hydrators::engagement_counts_hydrator::EngagementCountsHydrator;
 use crate::candidate_hydrators::filtered_topics_hydrator::FilteredTopicsHydrator;
@@ -330,6 +331,7 @@ impl PhoenixCandidatePipeline {
                 socialgraph_client: socialgraph_client.clone(),
             }),
             Box::new(core_data_hydrator),
+            Box::new(ConversationGapAncestorHydrator::new(tes_client.clone())),
             Box::new(QuoteHydrator::new(tes_client.clone(), socialgraph_client.clone()).await),
             Box::new(MediaInfoHydrator::new(media_info_cache_client).await),
             Box::new(SubscriptionHydrator::new(tes_client.clone()).await),


### PR DESCRIPTION
## Bug
Thunder stores reply ancestors as [in_reply_to, conversation_root] and skips tweets in the middle of the thread. reverse_chron already runs ConversationGapAncestorHydrator so Following VF sees the skipped ancestor. Phoenix For You did not.

VFCandidateHydrator only fetches and should_drop_ancillary only reads candidate.ancestors. A Drop on the skipped middle tweet never reaches AncillaryVFFilter, so the reply still serves.

This is not muted-keyword ancestor text (PR 96). Not VF dual-role merge (PR 55 / 90).

## Fix
Wire ConversationGapAncestorHydrator on the Phoenix candidate pipeline after core data, before QuoteHydrator. Same hydrator Following already uses. It expands [parent, root] to [parent, grandparent, root] when TES says the parent replies to someone else, and records tombstone ancestor ids.

## Proof
- Entry: Thunder ancestors [in_reply_to, conversation_root]
- Sink: VFCandidateHydrator oon_ids + should_drop_ancillary + AncillaryVFFilter
- Break: Phoenix never expanded the gap, so the skipped id was never VF-fetched
- Viewer effect: reply in a thread whose skipped ancestor is Drop still serves on For You
- Twin: reverse_chron ConversationGapAncestorHydrator

## Tests
- skipped_conversation_ancestor_does_not_drop_until_gap_expanded
- existing ConversationGapAncestorHydrator expansion tests
- unit tests added; cargo test cannot run in the public dump