### PR TITLE
Honor exclude_videos on quotes of video posts

### DIFF
--- a/home-mixer/candidate_hydrators/quote_hydrator.rs
+++ b/home-mixer/candidate_hydrators/quote_hydrator.rs
@@ -130,7 +130,8 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for QuoteHydrator {
             .into_iter()
             .collect();
 
-        let fetch_quoted_duration = query.params.get(EnableQuotedVqvDurationCheck);
+        let fetch_quoted_duration =
+            query.params.get(EnableQuotedVqvDurationCheck) || query.exclude_videos;
         let quoted_tweet_ids: Vec<u64> = if fetch_quoted_duration {
             resolved
                 .iter()

--- a/home-mixer/filters/video_filter.rs
+++ b/home-mixer/filters/video_filter.rs
@@ -14,9 +14,9 @@ impl Filter<ScoredPostsQuery, PostCandidate> for VideoFilter {
         _query: &ScoredPostsQuery,
         candidates: Vec<PostCandidate>,
     ) -> FilterResult<PostCandidate> {
-        let (kept, removed): (Vec<_>, Vec<_>) = candidates
-            .into_iter()
-            .partition(|c| c.min_video_duration_ms.is_none());
+        let (kept, removed): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|c| {
+            c.min_video_duration_ms.is_none() && c.quoted_video_duration_ms.is_none()
+        });
 
         FilterResult { kept, removed }
     }
@@ -95,5 +95,32 @@ mod tests {
         let result = VideoFilter.filter(&query, candidates);
         assert_eq!(result.kept.len(), 2);
         assert!(result.removed.is_empty());
+    }
+
+    #[test]
+    fn test_removes_quotes_of_videos() {
+        let query = ScoredPostsQuery {
+            exclude_videos: true,
+            ..Default::default()
+        };
+
+        let candidates = vec![
+            PostCandidate {
+                tweet_id: 1,
+                quoted_video_duration_ms: Some(5000),
+                ..Default::default()
+            },
+            PostCandidate {
+                tweet_id: 2,
+                quoted_video_duration_ms: None,
+                ..Default::default()
+            },
+        ];
+
+        let result = VideoFilter.filter(&query, candidates);
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 2);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 1);
     }
 }


### PR DESCRIPTION
## Bug
VideoFilter drops when min_video_duration_ms is set on the primary card. QuoteHydrator already hydrates quoted_video_duration_ms, but only when EnableQuotedVqvDurationCheck is on (ranking VQV). exclude_videos clients still saw quotes of videos.

This is not muted-keyword quoted text (PR 96). Not mute-on-quote author id (PR 23).

## Fix
Fetch quoted video duration when exclude_videos is set. VideoFilter drops if either the primary or the quoted duration is present.

QuoteHydrator is skipped for cached posts (has_cached_posts). Cached quote duration is leftover if the cache payload lacks quoted_video_duration_ms.

## Proof
- Entry: QuoteHydrator get_min_video_durations
- Sink: VideoFilter when query.exclude_videos
- Break: filter ignored quoted_video_duration_ms; hydrator skipped duration unless VQV param
- Viewer effect: exclude_videos request still serves a quote of a video
- Twin: min_video_duration_ms on the primary card

## Tests
- test_removes_quotes_of_videos
- existing primary video tests still pass
- unit tests added; cargo test cannot run in the public dump