### PR TITLE
Drop For You self-reply chains aimed at unfollowed users

### DIFF
--- a/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
+++ b/home-mixer/candidate_pipeline/phoenix_candidate_pipeline.rs
@@ -51,6 +51,7 @@ use crate::filters::previously_seen_posts_backup_filter::PreviouslySeenPostsBack
 use crate::filters::previously_seen_posts_filter::PreviouslySeenPostsFilter;
 use crate::filters::previously_served_posts_filter::PreviouslyServedPostsFilter;
 use crate::filters::retweet_deduplication_filter::RetweetDeduplicationFilter;
+use crate::filters::self_reply_chain_filter::SelfReplyChainFilter;
 use crate::filters::self_tweet_filter::SelfTweetFilter;
 use crate::filters::topic_ids_filter::TopicIdsFilter;
 use crate::filters::vf_filter::VFFilter;
@@ -348,6 +349,7 @@ impl PhoenixCandidatePipeline {
             Box::new(CoreDataHydrationFilter),
             Box::new(AgeFilter::new(Duration::from_secs(params::MAX_POST_AGE))),
             Box::new(SelfTweetFilter),
+            Box::new(SelfReplyChainFilter),
             Box::new(OONRetweetReplyFilter),
             Box::new(OONNsfwSimclustersFilter),
             Box::new(RetweetDeduplicationFilter),


### PR DESCRIPTION
## Bug
SelfReplyChainFilter already drops an in-network author replying to themselves toward someone the viewer does not follow. reverse_chron Following runs it. Phoenix For You did not.

CoreDataCandidateHydrator fills ancestor_users before filters. The filter keeps non-replies, missing ancestor_users, pure self-chains, and chains whose first non-self ancestor is followed or the viewer.

This is not OON reply drops (OONRetweetReplyFilter). Not conversation-gap VF ancestors (PR 97).

## Fix
Run SelfReplyChainFilter on the Phoenix candidate pipeline after SelfTweetFilter. Same filter Following already uses.

## Proof
- Entry: CoreDataCandidateHydrator ancestor_users
- Sink: SelfReplyChainFilter
- Break: Phoenix never wired the filter
- Viewer effect: followed author self-replies toward an unfollowed user still serve on For You
- Twin: reverse_chron SelfReplyChainFilter

## Tests
- existing drops_self_reply_directed_at_unfollowed_user
- existing keeps_pure_self_reply_chain / followed / viewer
- unit tests already on the filter; cargo test cannot run in the public dump