### PR TITLE
Drop replies whose conversation ancestors are muted or blocked

### DIFF
--- a/home-mixer/filters/author_socialgraph_filter.rs
+++ b/home-mixer/filters/author_socialgraph_filter.rs
@@ -42,12 +42,20 @@ impl Filter<ScoredPostsQuery, PostCandidate> for AuthorSocialgraphFilter {
                 .map(|uid| viewer_blocked_user_ids.contains(&(uid as i64)))
                 .unwrap_or(false);
 
+            // Conversation modules render ancestor tweets. Brazil already drops
+            // when ancestor_users hit the election list. Mute/block must too.
+            let viewer_mutes_or_blocks_ancestor = candidate.ancestor_users.iter().any(|&uid| {
+                let id = uid as i64;
+                viewer_muted_user_ids.contains(&id) || viewer_blocked_user_ids.contains(&id)
+            });
+
             if muted
                 || blocked
                 || author_blocks_viewer
                 || quoted_author_blocks_viewer
                 || viewer_blocks_quoted_author
                 || viewer_blocks_retweeted_user
+                || viewer_mutes_or_blocks_ancestor
             {
                 removed.push(candidate);
             } else {
@@ -331,5 +339,78 @@ mod tests {
         assert_eq!(result.removed.len(), 2);
         assert_eq!(result.removed[0].author_id, 100);
         assert_eq!(result.removed[1].author_id, 300);
+    }
+
+    fn make_reply(tweet_id: u64, author_id: u64, ancestor_users: Vec<u64>) -> PostCandidate {
+        PostCandidate {
+            tweet_id,
+            author_id,
+            in_reply_to_tweet_id: Some(tweet_id.saturating_sub(1)),
+            ancestor_users,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_muted_ancestor_author_is_removed() {
+        let filter = AuthorSocialgraphFilter;
+        let query = make_query_with_features(UserFeatures {
+            muted_user_ids: vec![200],
+            ..Default::default()
+        });
+
+        let candidates = vec![
+            make_candidate(1, 100),
+            make_reply(2, 300, vec![200, 400]),
+        ];
+
+        let result = filter.filter(&query, candidates);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 1);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 2);
+        assert_eq!(result.removed[0].author_id, 300);
+    }
+
+    #[tokio::test]
+    async fn test_blocked_ancestor_author_is_removed() {
+        let filter = AuthorSocialgraphFilter;
+        let query = make_query_with_features(UserFeatures {
+            blocked_user_ids: vec![200],
+            ..Default::default()
+        });
+
+        let candidates = vec![
+            make_candidate(1, 100),
+            make_reply(2, 300, vec![200, 400]),
+        ];
+
+        let result = filter.filter(&query, candidates);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 1);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 2);
+    }
+
+    #[tokio::test]
+    async fn test_unmuted_unblocked_ancestor_is_kept() {
+        let filter = AuthorSocialgraphFilter;
+        let query = make_query_with_features(UserFeatures {
+            muted_user_ids: vec![999],
+            blocked_user_ids: vec![888],
+            ..Default::default()
+        });
+
+        let candidates = vec![
+            make_candidate(1, 100),
+            make_reply(2, 300, vec![200, 400]),
+        ];
+
+        let result = filter.filter(&query, candidates);
+
+        assert_eq!(result.kept.len(), 2);
+        assert_eq!(result.removed.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary
AuthorSocialgraphFilter already drops when the viewer mutes or blocks the candidate author, and when the viewer blocks a quoted or retweeted author. Conversation modules still render ancestor tweets (root plus parent) from ancestor_users. Mute and block did not look at that list.

Brazil2026ElectionFilter already drops a reply when ancestor_users hits the listed-author set, with an explicit comment that ancestors are returned on the scored post for For You thread UI. This PR clones that ancestor edge for muted_user_ids and blocked_user_ids. One class, one file. No ranking changes.

This is not mute-on-quote (PR 23), not mute-on-retweet (PR 9), and not retweet original blocked-by (PR 100).

## Proof
- Entry: CoreDataCandidateHydrator.build_ancestor_users writes candidate.ancestor_users (parent author plus root author)
- Sink: AuthorSocialgraphFilter (Phoenix pre-selection and Following reverse-chron post-selection)
- Break: mute/block matched author_id, quoted_user_id, and retweeted_user_id; ancestor_users was Brazil-only
- Viewer effect: F replies to muted or blocked user Q; Home still serves the reply and convo_marshaller includes Q's tweet in the conversation module (unless tombstoned)
- Twin: Brazil2026ElectionFilter.should_remove ancestor_users any(is_excluded); FollowingViewerMutedKeywordFilter already matches ancestor_texts

## Test plan
- [ ] test_muted_ancestor_author_is_removed fails on main, passes on this branch
- [ ] test_blocked_ancestor_author_is_removed fails on main, passes on this branch
- [ ] test_unmuted_unblocked_ancestor_is_kept still keeps a reply whose ancestors are not muted or blocked
- [ ] unit tests added; cargo test cannot run in the public dump (no Home Mixer Cargo.toml)
