### PR TITLE
abuse-enforcement-service: fail closed when the allowlist store errors

### DIFF
--- a/abuse-enforcement-service/service-lib/src/allowlist.rs
+++ b/abuse-enforcement-service/service-lib/src/allowlist.rs
@@ -29,15 +29,17 @@ impl ManhattanAllowlist {
         }
     }
 
-    pub async fn get(&self, user_id: i64) -> Option<AllowlistRecord> {
-        let (entry, ttl_secs) = self.get_entity(EntityType::User, user_id).await?;
-        Some(AllowlistRecord {
-            user_id,
-            added_by: entry.added_by,
-            reason: entry.reason,
-            added_at: entry.added_at,
-            ttl_secs,
-        })
+    pub async fn get(&self, user_id: i64) -> anyhow::Result<Option<AllowlistRecord>> {
+        Ok(self
+            .get_entity(EntityType::User, user_id)
+            .await?
+            .map(|(entry, ttl_secs)| AllowlistRecord {
+                user_id,
+                added_by: entry.added_by,
+                reason: entry.reason,
+                added_at: entry.added_at,
+                ttl_secs,
+            }))
     }
 
     pub async fn add(
@@ -54,30 +56,41 @@ impl ManhattanAllowlist {
         self.remove_entity(EntityType::User, user_id).await
     }
 
+    /// Looks up an allowlist entry. `Ok(None)` means the store confirmed the
+    /// entity is absent. A store or decode failure is returned as `Err` so
+    /// callers can distinguish "not allowlisted" from "could not check", and
+    /// never treat an unreadable entry as not allowlisted.
     pub async fn get_entity(
         &self,
         entity_type: EntityType,
         entity_id: i64,
-    ) -> Option<(AllowlistEntry, i64)> {
+    ) -> anyhow::Result<Option<(AllowlistEntry, i64)>> {
         let lkey = Self::entity_lkey(entity_type, entity_id);
         let item = match self
             .client
             .get(self.tenant.clone(), [MH_PKEY], [lkey.as_str()])
             .await
         {
-            Ok(v) => v?,
+            Ok(Some(item)) => item,
+            Ok(None) => return Ok(None),
             Err(e) => {
-                warn!("Manhattan allowlist GET failed: {e}");
+                warn!("Manhattan allowlist GET failed for {lkey}: {e}");
                 crate::metrics::MANHATTAN_ERRORS_TOTAL.inc();
-                return None;
+                return Err(anyhow::anyhow!(
+                    "Manhattan allowlist GET failed for {lkey}: {e}"
+                ));
             }
         };
-        let entry: AllowlistEntry = serde_json::from_slice(item.value().as_bytes()).ok()?;
+        let entry: AllowlistEntry =
+            serde_json::from_slice(item.value().as_bytes()).map_err(|e| {
+                warn!("Manhattan allowlist entry decode failed for {lkey}: {e}");
+                anyhow::anyhow!("Manhattan allowlist entry decode failed for {lkey}: {e}")
+            })?;
         let ttl_secs = crate::manhattan::remaining_ttl_secs(
             item.expires_at()
                 .map(|d| d.timestamp_nanos_opt().unwrap_or(0) as u64),
         );
-        Some((entry, ttl_secs))
+        Ok(Some((entry, ttl_secs)))
     }
 
     pub async fn add_entity(

--- a/abuse-enforcement-service/service-lib/src/lib.rs
+++ b/abuse-enforcement-service/service-lib/src/lib.rs
@@ -248,7 +248,7 @@ async fn run_enforcement_inner(
     let mut facts = match entity_type {
         EntityType::User => {
             let user_id = entity_id;
-            let allowlist = fetch_user_allowlist(ctx.allowlist.as_ref(), user_id).await;
+            let allowlist = fetch_user_allowlist(ctx.allowlist.as_ref(), user_id).await?;
             if allowlist.is_allowlisted {
                 let partial = Facts {
                     entity_type,
@@ -295,6 +295,7 @@ async fn run_enforcement_inner(
                 fetch_entity_allowlist(ctx.allowlist.as_ref(), EntityType::Post, entity_id),
                 fetch_user_allowlist(ctx.allowlist.as_ref(), author_id),
             );
+            let (post_allowlist, author_allowlist) = (post_allowlist?, author_allowlist?);
             if post_allowlist.is_allowlisted || author_allowlist.is_allowlisted {
                 let reason = if post_allowlist.is_allowlisted {
                     "post_in_allowlist"

--- a/abuse-enforcement-service/service-lib/src/service.rs
+++ b/abuse-enforcement-service/service-lib/src/service.rs
@@ -1549,9 +1549,12 @@ pub async fn handle_allowlist_delete(
         );
     };
     info!("DELETE /api/allowlist/{user_id}");
+    // Audit snapshot only; a failed read must not block the delete.
     let before_json = al
         .get(user_id)
         .await
+        .ok()
+        .flatten()
         .map(|r| serde_json::to_string(&r).unwrap_or_default())
         .unwrap_or_default();
     let result = al.remove(user_id).await;
@@ -1619,7 +1622,21 @@ pub async fn bulk_allowlist_impl(
             continue;
         }
 
-        let existing_ttl = al.get(entry.user_id).await.map(|r| r.ttl_secs);
+        let existing_ttl = match al.get(entry.user_id).await {
+            Ok(existing) => existing.map(|r| r.ttl_secs),
+            Err(e) => {
+                errors += 1;
+                results.push(BulkRowResult {
+                    user_id: entry.user_id,
+                    ok: false,
+                    mode: String::new(),
+                    error: Some(format!("allowlist lookup failed: {e}")),
+                    existing_ttl_secs: None,
+                    ttl_secs: Some(entry.ttl_secs),
+                });
+                continue;
+            }
+        };
         let mode = if existing_ttl.is_some() {
             would_update += 1;
             "update"
@@ -1783,6 +1800,7 @@ pub async fn handle_allowlist_list(State(state): State<Arc<AppState>>) -> impl I
     responses(
         (status = 200, description = "Allowlist record for this user_id", body = AllowlistRecord),
         (status = 404, description = "No allowlist entry for this user_id"),
+        (status = 500, description = "Manhattan read failed"),
         (status = 503, description = "Allowlist not configured"),
     ),
 )]
@@ -1798,11 +1816,18 @@ pub async fn handle_allowlist_get(
         );
     };
     match al.get(user_id).await {
-        Some(record) => (
+        Ok(Some(record)) => (
             StatusCode::OK,
             Json(serde_json::to_value(&record).unwrap_or_default()),
         ),
-        None => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))),
+        Ok(None) => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))),
+        Err(e) => {
+            error!("GET /api/allowlist/{user_id} failed: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
     }
 }
 
@@ -1820,6 +1845,7 @@ pub async fn handle_allowlist_get(
         (status = 200, description = "Allowlist record for this entity", body = Object),
         (status = 400, description = "Unknown entity_type"),
         (status = 404, description = "No allowlist entry for this entity"),
+        (status = 500, description = "Manhattan read failed"),
         (status = 503, description = "Allowlist not configured"),
     ),
 )]
@@ -1843,7 +1869,7 @@ pub async fn handle_allowlist_get_entity(
         );
     };
     match al.get_entity(et, entity_id).await {
-        Some((entry, ttl_secs)) => (
+        Ok(Some((entry, ttl_secs))) => (
             StatusCode::OK,
             Json(json!({
                 "entity_type": et.as_str(),
@@ -1854,7 +1880,14 @@ pub async fn handle_allowlist_get_entity(
                 "ttl_secs": ttl_secs,
             })),
         ),
-        None => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))),
+        Ok(None) => (StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))),
+        Err(e) => {
+            error!("GET /api/allowlist/{}/{entity_id} failed: {e}", et.as_str());
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
     }
 }
 
@@ -2009,9 +2042,12 @@ pub async fn handle_allowlist_delete_entity(
         );
     };
     info!("DELETE /api/allowlist/{}/{entity_id}", et.as_str());
+    // Audit snapshot only; a failed read must not block the delete.
     let before_json = al
         .get_entity(et, entity_id)
         .await
+        .ok()
+        .flatten()
         .map(|(entry, ttl_secs)| {
             json!({
                 "entity_type": et.as_str(),

--- a/abuse-enforcement-service/service-lib/src/strato.rs
+++ b/abuse-enforcement-service/service-lib/src/strato.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use tracing::{info, warn};
 use xai_strato::Strato;
 
-use crate::allowlist::ManhattanAllowlist;
+use crate::allowlist::{AllowlistEntry, ManhattanAllowlist};
 use crate::entities::{self, HighPageRankUser};
 use crate::facts::{AllowlistFacts, CredFacts, EntityType, GizmoduckFacts};
 use crate::gizmoduck::GizmoduckCoreClient;
@@ -56,37 +56,45 @@ where
     }
 }
 
+/// Turns the result of an allowlist store lookup into facts.
+///
+/// A store error is propagated rather than mapped to `is_allowlisted: false`:
+/// the allowlist is an exemption, so "could not check" must stop enforcement
+/// (the caller retries) instead of silently reading as "not exempt". Only a
+/// confirmed `Ok(None)` from the store means the entity is not allowlisted.
+fn allowlist_facts(lookup: Result<Option<(AllowlistEntry, i64)>>) -> Result<AllowlistFacts> {
+    Ok(match lookup? {
+        Some((entry, ttl_secs)) => AllowlistFacts {
+            is_allowlisted: true,
+            added_by: Some(entry.added_by),
+            reason: Some(entry.reason),
+            ttl_secs: Some(ttl_secs),
+        },
+        None => AllowlistFacts::default(),
+    })
+}
+
 #[tracing::instrument(skip_all, fields(is_allowlisted))]
 pub async fn fetch_user_allowlist(
     allowlist: Option<&ManhattanAllowlist>,
     user_id: i64,
-) -> AllowlistFacts {
+) -> Result<AllowlistFacts> {
     let span = tracing::Span::current();
     let Some(al) = allowlist else {
         span.record("is_allowlisted", false);
-        return AllowlistFacts::default();
+        return Ok(AllowlistFacts::default());
     };
-    match al.get(user_id).await {
-        Some(record) => {
-            span.record("is_allowlisted", true);
-            warn!(
-                added_by = record.added_by,
-                ttl_secs = record.ttl_secs,
-                reason = record.reason,
-                "user is in allowlist; will skip",
-            );
-            AllowlistFacts {
-                is_allowlisted: true,
-                added_by: Some(record.added_by),
-                reason: Some(record.reason),
-                ttl_secs: Some(record.ttl_secs),
-            }
-        }
-        None => {
-            span.record("is_allowlisted", false);
-            AllowlistFacts::default()
-        }
+    let facts = allowlist_facts(al.get_entity(EntityType::User, user_id).await)?;
+    span.record("is_allowlisted", facts.is_allowlisted);
+    if facts.is_allowlisted {
+        warn!(
+            added_by = facts.added_by.as_deref(),
+            ttl_secs = facts.ttl_secs,
+            reason = facts.reason.as_deref(),
+            "user is in allowlist; will skip",
+        );
     }
+    Ok(facts)
 }
 
 #[tracing::instrument(skip_all, fields(entity_type = entity_type.as_str(), is_allowlisted))]
@@ -94,34 +102,24 @@ pub async fn fetch_entity_allowlist(
     allowlist: Option<&ManhattanAllowlist>,
     entity_type: EntityType,
     entity_id: i64,
-) -> AllowlistFacts {
+) -> Result<AllowlistFacts> {
     let span = tracing::Span::current();
     let Some(al) = allowlist else {
         span.record("is_allowlisted", false);
-        return AllowlistFacts::default();
+        return Ok(AllowlistFacts::default());
     };
-    match al.get_entity(entity_type, entity_id).await {
-        Some((entry, ttl_secs)) => {
-            span.record("is_allowlisted", true);
-            warn!(
-                entity_id,
-                added_by = entry.added_by,
-                ttl_secs,
-                reason = entry.reason,
-                "entity is in allowlist; will skip",
-            );
-            AllowlistFacts {
-                is_allowlisted: true,
-                added_by: Some(entry.added_by),
-                reason: Some(entry.reason),
-                ttl_secs: Some(ttl_secs),
-            }
-        }
-        None => {
-            span.record("is_allowlisted", false);
-            AllowlistFacts::default()
-        }
+    let facts = allowlist_facts(al.get_entity(entity_type, entity_id).await)?;
+    span.record("is_allowlisted", facts.is_allowlisted);
+    if facts.is_allowlisted {
+        warn!(
+            entity_id,
+            added_by = facts.added_by.as_deref(),
+            ttl_secs = facts.ttl_secs,
+            reason = facts.reason.as_deref(),
+            "entity is in allowlist; will skip",
+        );
     }
+    Ok(facts)
 }
 
 pub async fn fetch_user(gd: &GizmoduckCoreClient, user_id: i64) -> Result<GizmoduckFacts> {
@@ -279,5 +277,41 @@ mod tests {
         let json = r#"{"v": true}"#;
         let r: entities::StratoResponse<bool> = serde_json::from_str(json).unwrap();
         assert_eq!(r.v, Some(true));
+    }
+
+    #[test]
+    fn allowlist_facts_absent_is_not_allowlisted() {
+        let f = allowlist_facts(Ok(None)).unwrap();
+        assert!(!f.is_allowlisted);
+        assert_eq!(f.added_by, None);
+        assert_eq!(f.reason, None);
+        assert_eq!(f.ttl_secs, None);
+    }
+
+    #[test]
+    fn allowlist_facts_present_is_allowlisted() {
+        let entry = AllowlistEntry {
+            added_by: "oncall".into(),
+            reason: "false positive".into(),
+            added_at: 1_700_000_000,
+        };
+        let f = allowlist_facts(Ok(Some((entry, 3600)))).unwrap();
+        assert!(f.is_allowlisted);
+        assert_eq!(f.added_by.as_deref(), Some("oncall"));
+        assert_eq!(f.reason.as_deref(), Some("false positive"));
+        assert_eq!(f.ttl_secs, Some(3600));
+    }
+
+    #[test]
+    fn allowlist_facts_store_error_is_not_read_as_not_allowlisted() {
+        let err = allowlist_facts(Err(anyhow::anyhow!("manhattan unavailable")));
+        assert!(
+            err.is_err(),
+            "a failed allowlist lookup must propagate as an error, not as is_allowlisted=false"
+        );
+        assert!(err
+            .unwrap_err()
+            .to_string()
+            .contains("manhattan unavailable"));
     }
 }


### PR DESCRIPTION
## Problem

The allowlist is the exemption check before enforcement rules fire. A Manhattan GET failure during that check was returned as None and treated as not allowlisted, so rules could run (including toward suspend) against accounts that may have been exempt. Neighbouring Gizmoduck and credibility fetches on the same path abort and retry; only the exemption lookup failed toward enforcement.

## Change

Make the allowlist lookup fail closed toward retry, like the other critical fetches.

- get / get_entity return Result Option (Ok None = confirmed absent; store errors / undecodable entries = Err)
- Fetch helpers propagate errors; store errors abort into the existing retry queue instead of proceeding to rules
- Admin GETs return 500 on read error instead of 404

No change when the store is healthy. No rule or action changes.

## Tests

Unit tests for the lookup-to-facts conversion, including asserting a store error is not turned into is_allowlisted=false.

Related fork PR: https://github.com/Pitchfork-and-Torch/x-algorithm/pull/7