### PR TITLE
scarecrow: make stale NSFW_CARD_IMAGE URL verdict cleanup reachable

### DIFF
--- a/botmaker-rules/scarecrow/bot/NSFW_Card_Image_Media_To_URL_Verdict.bot
+++ b/botmaker-rules/scarecrow/bot/NSFW_Card_Image_Media_To_URL_Verdict.bot
@@ -4,7 +4,7 @@ condition: |
   Exists(category) &&
   Exists(entityId) &&
   category == "CARD_IMAGE" &&
-  IsNearPerfectNsfw
+  (IsNearPerfectNsfw || (Exists(precisionNewNsfw) && !IsHighRecallNsfw && !IsHighPrecisionNsfw))
 action: |
   {
     val :cardUrlLastHop = entityId;
@@ -18,11 +18,13 @@ action: |
       Log("nsfw_card_url_log", :cardUrlLastHop);
       IncrementStat("URLs_added_as_NSFW_CARD_IMAGE_in_Rep_Store", 1);
     }  else if(:verdict == "NSFW_CARD_IMAGE" &&
+      Exists(precisionNewNsfw) &&
       !IsHighRecallNsfw &&
       !IsHighPrecisionNsfw
     ) {
-      val :verdictCreationTime = DictGetOrElse(:lastHopVerdict, "creationTimestampInSec", 0);
-      if(:verdictCreationTime - (CurrentTimeMs()/1000) > (60 * 60 * 1000)) {
+      val :verdictCreationTimeInSec = DictGetOrElse(:lastHopVerdict, "creationTimestampInSec", 0);
+      val :verdictAgeInSec = (CurrentTimeMs() / 1000) - :verdictCreationTimeInSec;
+      if(:verdictAgeInSec > (60 * 60)) {
         DeleteUrlVerdictIf(:cardUrlLastHop, "EXACT_URL_MATCH", "NSFW_CARD_IMAGE", Join("_", "bot", RULE_ID), "botmaker");
         IncrementStat("URLs_removed_as_NSFW_CARD_IMAGE_in_Rep_Store", 1);
       };


### PR DESCRIPTION
## Problem

Rule 7429 writes a 7-day NSFW_CARD_IMAGE verdict on near-perfect NSFW card images. Its cleanup branch was meant to delete that verdict when a later score is clean, but it could never run: contradictory guards, inverted age check, and wrong time units.

False-positive card URL labels therefore lasted the full TTL, interstitialing linked posts and dropping them from out-of-network recommendations with no automatic correction.

## Change

Make the cleanup branch reachable and arithmetically correct. Leave the write path untouched.

Fork PR: https://github.com/Pitchfork-and-Torch/x-algorithm/pull/8