### PR TITLE
under-the-hood: count still-labeled posts, not cleared ones, in the report

### DIFF
--- a/under-the-hood/strato/columns/underTheHoodReport.User.strato
+++ b/under-the-hood/strato/columns/underTheHoodReport.User.strato
@@ -145,9 +145,11 @@ def generatedAtMillis(daysIncluded: Option[UthDaysIncluded], fallbackMs: Long): 
 def formatGeneratedAtIso(ms: Long): String =
   utcIsoSeconds.format(Time.fromMilliseconds(ms))
 
+// carried = ever labeled in the window; removed = later cleared. Report net.
 def sumCarried(days: Option[Seq[UthDayCarriedRemoved]]): Long =
   days.getOrElse(Seq.empty).foldLeft(0L) { (acc, d) =>
-    acc + d.carried.getOrElse(0L)
+    val stillLabeled = d.carried.getOrElse(0L) - d.removed.getOrElse(0L)
+    acc + (if (stillLabeled > 0L) stillLabeled else 0L)
   }
 
 def sumDayCounts(days: Option[Seq[UthDayCount]]): Long =


### PR DESCRIPTION
## Problem

The daily Under the Hood post-label job writes `carried` (posts that received the label in the observation window) and `removed` (how many of those were later taken off or expired). The monthly aggregate keeps both. The public report summed only `carried` and published that as `posts` / `percentageOfPosts`.

A post that was labeled and later cleared still counted. The label copy next to that number is present tense ("Post hidden from recommendations to non-followers"). Readers were told more of their posts were still limited than still carried the label.

`removed` is computed, written to daily parquet, copied into the monthly aggregate, and was then ignored by the only user-facing reader.

## Change

`sumCarried` now reports `max(0, carried - removed)` per day. Missing `removed` is treated as 0. Daily and monthly writers are unchanged; existing month rows already have both fields.

## Why it matters

Under the Hood is the public account of which labels limited a person's posts. Overstating the still-labeled count makes reach look more restricted than the stored data says, and it hides that a label expired or was taken off.

Fork PR: https://github.com/Pitchfork-and-Torch/x-algorithm/pull/9