### PR TITLE
Drop Following posts whose author blocked the viewer

### DIFF
--- a/home-mixer/candidate_hydrators/following_blocked_by_hydrator.rs
+++ b/home-mixer/candidate_hydrators/following_blocked_by_hydrator.rs
@@ -1,5 +1,6 @@
 use crate::models::candidate::PostCandidate;
 use crate::models::query::ScoredPostsQuery;
+use std::collections::HashSet;
 use std::sync::Arc;
 use tonic::async_trait;
 use xai_candidate_pipeline::component_library::clients::SocialGraphClientOps;
@@ -24,7 +25,13 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for FollowingBlockedByHydrator {
     ) -> Vec<Result<PostCandidate, String>> {
         let user_ids: Vec<u64> = candidates
             .iter()
-            .flat_map(|c| c.quoted_user_id.into_iter().chain(c.retweeted_user_id))
+            .flat_map(|c| {
+                std::iter::once(c.author_id)
+                    .chain(c.quoted_user_id)
+                    .chain(c.retweeted_user_id)
+            })
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect();
 
         let blocked_by_user_ids = match self
@@ -41,9 +48,10 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for FollowingBlockedByHydrator {
         candidates
             .iter()
             .map(|candidate| {
-                let author_blocks_viewer = candidate
-                    .retweeted_user_id
-                    .is_some_and(|uid| blocked_by_user_ids.contains(&uid));
+                let author_blocks_viewer = blocked_by_user_ids.contains(&candidate.author_id)
+                    || candidate
+                        .retweeted_user_id
+                        .is_some_and(|uid| blocked_by_user_ids.contains(&uid));
                 let quoted_author_blocks_viewer = candidate
                     .quoted_user_id
                     .map(|uid| blocked_by_user_ids.contains(&uid));
@@ -61,5 +69,151 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for FollowingBlockedByHydrator {
         if hydrated.quoted_author_blocks_viewer.is_some() {
             candidate.quoted_author_blocks_viewer = hydrated.quoted_author_blocks_viewer;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Status;
+
+    struct MockSocialGraph {
+        blocked_by: HashSet<u64>,
+    }
+
+    #[async_trait]
+    impl SocialGraphClientOps for MockSocialGraph {
+        async fn get_following_list(&self, _user_id: u64) -> Result<Vec<u64>, Status> {
+            Ok(vec![])
+        }
+        async fn check_blocked_by(
+            &self,
+            _viewer_id: u64,
+            author_ids: &[u64],
+        ) -> Result<HashSet<u64>, Status> {
+            Ok(author_ids
+                .iter()
+                .copied()
+                .filter(|id| self.blocked_by.contains(id))
+                .collect())
+        }
+        async fn check_followed_by(
+            &self,
+            _viewer_id: u64,
+            _user_ids: &[u64],
+        ) -> Result<HashSet<u64>, Status> {
+            Ok(HashSet::new())
+        }
+        async fn get_blocked_user_ids(&self, _viewer_id: u64) -> Result<Vec<i64>, Status> {
+            Ok(vec![])
+        }
+        async fn get_muted_user_ids(&self, _viewer_id: u64) -> Result<Vec<i64>, Status> {
+            Ok(vec![])
+        }
+        async fn get_followed_user_ids(&self, _viewer_id: u64) -> Result<Vec<i64>, Status> {
+            Ok(vec![])
+        }
+        async fn get_follower_ids(&self, _user_id: u64) -> Result<Vec<i64>, Status> {
+            Ok(vec![])
+        }
+        async fn get_subscribed_user_ids(&self, _viewer_id: u64) -> Result<Vec<i64>, Status> {
+            Ok(vec![])
+        }
+        async fn get_device_following_user_ids(&self, _viewer_id: u64) -> Result<Vec<i64>, Status> {
+            Ok(vec![])
+        }
+        async fn get_hide_recommendations_user_ids(
+            &self,
+            _viewer_id: u64,
+        ) -> Result<Vec<i64>, Status> {
+            Ok(vec![])
+        }
+    }
+
+    fn hydrator(blocked_by: HashSet<u64>) -> FollowingBlockedByHydrator {
+        FollowingBlockedByHydrator {
+            socialgraph_client: Arc::new(MockSocialGraph { blocked_by }),
+        }
+    }
+
+    #[tokio::test]
+    async fn native_author_who_blocked_viewer_is_marked() {
+        let hydrator = hydrator(HashSet::from([10]));
+        let mut native = PostCandidate {
+            tweet_id: 1,
+            author_id: 10,
+            ..Default::default()
+        };
+        let query = ScoredPostsQuery {
+            user_id: 1,
+            ..Default::default()
+        };
+        let hydrated = hydrator.hydrate(&query, &[native.clone()]).await;
+        hydrator.update(&mut native, hydrated[0].clone().unwrap());
+        assert_eq!(native.author_blocks_viewer, Some(true));
+    }
+
+    #[tokio::test]
+    async fn retweet_of_author_who_blocked_viewer_is_still_marked() {
+        let hydrator = hydrator(HashSet::from([99]));
+        let rt = PostCandidate {
+            tweet_id: 1,
+            author_id: 10,
+            retweeted_user_id: Some(99),
+            ..Default::default()
+        };
+        let native = PostCandidate {
+            tweet_id: 2,
+            author_id: 10,
+            ..Default::default()
+        };
+        let query = ScoredPostsQuery {
+            user_id: 1,
+            ..Default::default()
+        };
+        let hydrated = hydrator.hydrate(&query, &[rt.clone(), native.clone()]).await;
+        let mut rt = rt;
+        let mut native = native;
+        hydrator.update(&mut rt, hydrated[0].clone().unwrap());
+        hydrator.update(&mut native, hydrated[1].clone().unwrap());
+        assert_eq!(rt.author_blocks_viewer, Some(true));
+        assert_eq!(native.author_blocks_viewer, Some(false));
+    }
+
+    #[tokio::test]
+    async fn retweeter_who_blocked_viewer_is_marked() {
+        let hydrator = hydrator(HashSet::from([10]));
+        let mut rt = PostCandidate {
+            tweet_id: 1,
+            author_id: 10,
+            retweeted_user_id: Some(99),
+            ..Default::default()
+        };
+        let query = ScoredPostsQuery {
+            user_id: 1,
+            ..Default::default()
+        };
+        let hydrated = hydrator.hydrate(&query, &[rt.clone()]).await;
+        hydrator.update(&mut rt, hydrated[0].clone().unwrap());
+        assert_eq!(rt.author_blocks_viewer, Some(true));
+    }
+
+    #[tokio::test]
+    async fn quoted_author_who_blocked_viewer_is_still_marked() {
+        let hydrator = hydrator(HashSet::from([77]));
+        let mut quote = PostCandidate {
+            tweet_id: 1,
+            author_id: 10,
+            quoted_user_id: Some(77),
+            ..Default::default()
+        };
+        let query = ScoredPostsQuery {
+            user_id: 1,
+            ..Default::default()
+        };
+        let hydrated = hydrator.hydrate(&query, &[quote.clone()]).await;
+        hydrator.update(&mut quote, hydrated[0].clone().unwrap());
+        assert_eq!(quote.quoted_author_blocks_viewer, Some(true));
+        assert_eq!(quote.author_blocks_viewer, Some(false));
     }
 }


### PR DESCRIPTION
## Bug
FollowingBlockedByHydrator asked socialgraph whether quoted_user_id or retweeted_user_id blocked the viewer. It never sent candidate.author_id. AuthorSocialgraphFilter then drops on author_blocks_viewer (unwrap_or false).

A native Following post from an author who blocked the viewer still served: author_blocks_viewer was written from retweeted_user_id only, so a non-retweet was Some(false). VFFilter None is fail-open, but this path is worse: it claims the author did not block the viewer.

Phoenix BlockedByHydrator already checks author_id. PR 100 added retweeted_user_id on For You. This is the Following twin of that missing native-author edge. This is not mute-on-retweet (PR 9) and not quote mute (PR 23).

## Fix
Include author_id in check_blocked_by. Set author_blocks_viewer if either the primary author or the original retweeted author blocked the viewer. Keep quoted_author_blocks_viewer on quoted_user_id.

## Proof
- Entry: FollowingBlockedByHydrator check_blocked_by on reverse-chron Following
- Sink: AuthorSocialgraphFilter author_blocks_viewer
- Break: Following never passed author_id into blocked-by
- Viewer effect: user blocked by A still sees A's native Following post (and A's retweet of B)
- Twin: Phoenix BlockedByHydrator author_id (PR 100 is the retweet original twin)

## Tests
- native_author_who_blocked_viewer_is_marked (fails on unmodified main)
- retweet_of_author_who_blocked_viewer_is_still_marked
- retweeter_who_blocked_viewer_is_marked
- quoted_author_who_blocked_viewer_is_still_marked
- unit tests added; cargo test cannot run in the public dump (no Home Mixer Cargo.toml)
