### PR TITLE
Honor account country when applying geo media and legal takedown rules

### DIFF
--- a/visibility-filtering/rules/context.rs
+++ b/visibility-filtering/rules/context.rs
@@ -259,7 +259,12 @@ impl TakedownPredicates<'_> {
 
     #[inline]
     fn in_viewer_country(&self, extractor: fn(&TakedownReason) -> Option<&str>) -> bool {
-        let viewer_country = self.ctx.viewer.country_code.as_deref();
+        let viewer_country = self
+            .ctx
+            .viewer
+            .account_country_code
+            .as_deref()
+            .or(self.ctx.viewer.country_code.as_deref());
         self.ctx
             .candidate
             .tweet_features
@@ -278,8 +283,9 @@ impl TakedownPredicates<'_> {
         let country = self
             .ctx
             .viewer
-            .country_code
+            .account_country_code
             .as_deref()
+            .or(self.ctx.viewer.country_code.as_deref())
             .unwrap_or(WORLDWIDE_COUNTRY_CODE);
         let allow = &self.ctx.candidate.tweet_features.media.geo_allow_list;
         let deny = &self.ctx.candidate.tweet_features.media.geo_deny_list;

--- a/visibility-filtering/rules/golden_corpus.rs
+++ b/visibility-filtering/rules/golden_corpus.rs
@@ -171,6 +171,13 @@ fn viewer_in_country(code: &str) -> ViewerFeatures {
     }
 }
 
+fn viewer_with_account_country(code: &str) -> ViewerFeatures {
+    ViewerFeatures {
+        account_country_code: Some(code.to_string()),
+        ..viewer(VIEWER_ID)
+    }
+}
+
 fn viewer_with_age(age: ViewerAge) -> ViewerFeatures {
     ViewerFeatures {
         viewer_age: age,
@@ -799,6 +806,22 @@ fn oon_media_cases() -> Vec<Case> {
             level: TimelineHomeRecommendations,
             viewer: viewer(VIEWER_ID),
             candidate: tweet_candidate(|t| t.media.geo_allow_list = vec!["us".to_string()]),
+            expected_action: Drop(FilteredReason::UnspecifiedReason),
+            expected_decided_by: Some("DropTweetsWithGeoRestrictedMediaRule"),
+        },
+        Case {
+            name: "geo_allow_listed_media_allows_account_country_when_request_country_missing",
+            level: TimelineHomeRecommendations,
+            viewer: viewer_with_account_country("us"),
+            candidate: tweet_candidate(|t| t.media.geo_allow_list = vec!["us".to_string()]),
+            expected_action: Allow,
+            expected_decided_by: None,
+        },
+        Case {
+            name: "geo_denied_media_drops_account_country_oon",
+            level: TimelineHomeRecommendations,
+            viewer: viewer_with_account_country("de"),
+            candidate: tweet_candidate(|t| t.media.geo_deny_list = vec!["de".to_string()]),
             expected_action: Drop(FilteredReason::UnspecifiedReason),
             expected_decided_by: Some("DropTweetsWithGeoRestrictedMediaRule"),
         },


### PR DESCRIPTION
## Bug
DropTweetsWithGeoRestrictedMediaRule calls media_restricted_in_viewer_country. That helper reads only request country_code and treats a missing value as xx (worldwide). ViewerPredicates.country() already prefers account_country_code, then request country.

A US-account viewer with no request country is dropped from US allow-listed media on TimelineHomeRecommendations. Legal/local takedown helpers had the same request-only hole.

This is not safety-label applicable_countries (PR 110). Media geo lists and takedown reasons are a different object.

## Fix
Resolve viewer country as account_country_code, then country_code, then xx for media. Legal/local takedown uses the same account-then-request pair. Missing both still drops allow-listed media (existing unknown-country case).

## Proof
- Entry: media geo_allow_list / geo_deny_list; takedown_reasons
- Sink: DropTweetsWithGeoRestrictedMediaRule / legal takedown Drops
- Break: request country_code only; account country ignored
- Viewer effect: US-account viewer, no request country, US allow-listed video disappears from For You
- Twin: ViewerPredicates.country() already prefers account_country_code

## Tests
- geo_allow_listed_media_allows_account_country_when_request_country_missing (fails on unmodified main)
- geo_denied_media_drops_account_country_oon
- geo_allow_listed_media_drops_unknown_country_oon still drops when both countries are missing
- unit tests added; cargo test cannot run in the public dump
