### PR TITLE
Fail closed when QuoteHydrator TES or socialgraph lookup fails

### DIFF
--- a/home-mixer/candidate_hydrators/quote_hydrator.rs
+++ b/home-mixer/candidate_hydrators/quote_hydrator.rs
@@ -50,14 +50,18 @@ impl QuoteHydrator {
         }
     }
 
-    async fn get_blocked_by(&self, viewer_id: u64, quoted_user_ids: Vec<u64>) -> HashSet<u64> {
+    async fn get_blocked_by(
+        &self,
+        viewer_id: u64,
+        quoted_user_ids: Vec<u64>,
+    ) -> Result<HashSet<u64>, String> {
         if quoted_user_ids.is_empty() {
-            return HashSet::new();
+            return Ok(HashSet::new());
         }
         self.socialgraph_client
             .check_blocked_by(viewer_id, &quoted_user_ids)
             .await
-            .unwrap_or_default()
+            .map_err(|e| e.to_string())
     }
 }
 
@@ -81,6 +85,7 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for QuoteHydrator {
         let tweet_ids: Vec<u64> = candidates.iter().map(|c| c.tweet_id).collect();
 
         let mut cache_misses: Vec<u64> = Vec::new();
+        let mut tes_failed: HashSet<u64> = HashSet::new();
         let mut resolved: Vec<(u64, Option<u64>, Option<u64>)> =
             Vec::with_capacity(tweet_ids.len());
 
@@ -104,22 +109,37 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for QuoteHydrator {
                 if !cache_misses.contains(&tweet_id) {
                     continue;
                 }
-                let (qt_tweet_id, qt_user_id) = match quoted_tweets.get(&tweet_id) {
-                    Some(Ok(Some(qt))) => (Some(qt.tweet_id), Some(qt.user_id)),
-                    _ => (None, None),
-                };
-                entry.1 = qt_tweet_id;
-                entry.2 = qt_user_id;
-
-                self.cache
-                    .insert(
-                        tweet_id,
-                        QuoteCacheValue {
-                            quoted_tweet_id: qt_tweet_id,
-                            quoted_user_id: qt_user_id,
-                        },
-                    )
-                    .await;
+                match quoted_tweets.get(&tweet_id) {
+                    Some(Ok(Some(qt))) => {
+                        entry.1 = Some(qt.tweet_id);
+                        entry.2 = Some(qt.user_id);
+                        self.cache
+                            .insert(
+                                tweet_id,
+                                QuoteCacheValue {
+                                    quoted_tweet_id: Some(qt.tweet_id),
+                                    quoted_user_id: Some(qt.user_id),
+                                },
+                            )
+                            .await;
+                    }
+                    Some(Ok(None)) => {
+                        entry.1 = None;
+                        entry.2 = None;
+                        self.cache
+                            .insert(
+                                tweet_id,
+                                QuoteCacheValue {
+                                    quoted_tweet_id: None,
+                                    quoted_user_id: None,
+                                },
+                            )
+                            .await;
+                    }
+                    _ => {
+                        tes_failed.insert(tweet_id);
+                    }
+                }
             }
         }
 
@@ -142,14 +162,20 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for QuoteHydrator {
             Vec::new()
         };
 
-        let (blocked_by, quoted_durations) = tokio::join!(
-            self.get_blocked_by(query.user_id, quoted_user_ids),
-            self.get_quoted_video_durations(quoted_tweet_ids),
-        );
+        let quoted_durations = self.get_quoted_video_durations(quoted_tweet_ids).await;
+        let blocked_by = match self.get_blocked_by(query.user_id, quoted_user_ids).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                return candidates.iter().map(|_| Err(e.clone())).collect();
+            }
+        };
 
         resolved
             .iter()
-            .map(|(_, qt_tweet_id, qt_user_id)| {
+            .map(|(tweet_id, qt_tweet_id, qt_user_id)| {
+                if tes_failed.contains(tweet_id) {
+                    return Err(format!("TES quoted-tweet lookup failed for {tweet_id}"));
+                }
                 let quoted_author_blocks_viewer = qt_user_id
                     .map(|uid| blocked_by.contains(&uid))
                     .unwrap_or(false);


### PR DESCRIPTION
## Bug

For You `QuoteHydrator` treats TES and socialgraph failure as "not a quote".

TES miss or `Err` was cached as `quoted_tweet_id = None`. Later VF, mute, and blocked-by never see the inner tweet. Following Night Owl already carries `quoted_tweet_id` on the search hit, so reverse-chron still VF-evaluates the quote.

Socialgraph `check_blocked_by` used `unwrap_or_default()`. Empty set => `quoted_author_blocks_viewer = false`. Following `FollowingBlockedByHydrator` returns `Err` for the batch on the same RPC failure.

- Entry: Phoenix `QuoteHydrator` (`phoenix_candidate_pipeline.rs`)
- Sink: `should_drop_ancillary` (needs Some quoted id), `AuthorSocialgraphFilter` quoted blocked-by
- Break: TES miss cached as no-quote; graph fail becomes not-blocked
- Viewer effect: quote of a VF-Drop / blocked author serves as a normal For You card; miss stays cached after TES recovers
- Twin: Following Night Owl keeps quote ids; `FollowingBlockedByHydrator` fail-closes graph errors

This is not PR 7 (mixer author graph filter). This is not PR 94 (core TES wiping retweet/reply ids). This is not PR 23 (mute quoted author when the id is present).

## Fix

Do not cache TES lookup failure. Surface `Err` so `update` does not write a fake None. Fail the batch when socialgraph blocked-by errors, matching Following.

Genuine `Ok(None)` (not a quote) is still cached.

## Tests

cargo: cannot run. Public dump has no Home Mixer manifest.
