### PR TITLE
Stop VF hydrator from ignoring original-tweet verdicts on retweets

### DIFF
--- a/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
@@ -115,7 +115,7 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for VFCandidateHydrator {
 
         let mut hydrated_candidates = Vec::with_capacity(candidates.len());
         for candidate in candidates {
-            let primary_result = all_results.get(&candidate.tweet_id);
+            let primary_result = all_results.get(&primary_vf_id(candidate));
             let visibility_reason = match primary_result {
                 Some(Ok(Some(reason))) => Some(reason.clone()),
                 _ => None,
@@ -140,6 +140,10 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for VFCandidateHydrator {
         candidate.visibility_reason = hydrated.visibility_reason;
         candidate.drop_ancillary_posts = hydrated.drop_ancillary_posts;
     }
+}
+
+pub(crate) fn primary_vf_id(candidate: &PostCandidate) -> u64 {
+    candidate.retweeted_tweet_id.unwrap_or(candidate.tweet_id)
 }
 
 pub(crate) fn should_drop_ancillary(
@@ -180,5 +184,153 @@ fn should_drop_reason(reason: &FilteredReason) -> bool {
             matches!(safety_result.action, Action::Drop(_))
         }
         _ => true, 
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_safety_label_store::types::SafetyLabelMap;
+    use xai_visibility_filtering::models::{
+        Action, DropReason, SafetyResult, SafetyResultReason,
+    };
+
+    struct MapClient {
+        results: HashMap<u64, FilteredReason>,
+    }
+
+    fn vis(reason: FilteredReason) -> TweetVisibility {
+        TweetVisibility {
+            reason: Some(reason),
+            safety_labels: Ok(SafetyLabelMap::default()),
+        }
+    }
+
+    fn interstitial() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: Some(SafetyResultReason::NsfwHighPrecision),
+            action: Action::Interstitial,
+        })
+    }
+
+    fn allow() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: None,
+            action: Action::Allow,
+        })
+    }
+
+    fn drop_reason() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: Some(SafetyResultReason::NsfwHighPrecision),
+            action: Action::Drop(DropReason {}),
+        })
+    }
+
+    #[async_trait]
+    impl VfClient for MapClient {
+        async fn get_result(
+            &self,
+            post_ids: Vec<u64>,
+            _safety_level: SafetyLevel,
+            _for_user_id: u64,
+            _context: Option<TwitterContextViewer>,
+        ) -> HashMap<u64, Result<TweetVisibility>> {
+            post_ids
+                .into_iter()
+                .filter_map(|id| {
+                    self.results
+                        .get(&id)
+                        .cloned()
+                        .map(|reason| (id, Ok(vis(reason))))
+                })
+                .collect()
+        }
+    }
+
+    async fn hydrate(
+        results: HashMap<u64, FilteredReason>,
+        candidates: &[PostCandidate],
+    ) -> Vec<std::result::Result<PostCandidate, String>> {
+        let client = Arc::new(MapClient { results });
+        VFCandidateHydrator::new(client.clone(), client)
+            .await
+            .hydrate(&ScoredPostsQuery::default(), candidates)
+            .await
+    }
+
+    #[tokio::test]
+    async fn native_post_still_uses_its_own_id() {
+        let results = hydrate(
+            HashMap::from([(20, interstitial())]),
+            &[PostCandidate {
+                tweet_id: 20,
+                in_network: Some(true),
+                ..Default::default()
+            }],
+        )
+        .await;
+        let hydrated = results[0].as_ref().unwrap();
+        assert!(matches!(
+            hydrated.visibility_reason,
+            Some(FilteredReason::SafetyResult(ref s)) if s.action == Action::Interstitial
+        ));
+        assert_eq!(hydrated.drop_ancillary_posts, Some(false));
+    }
+
+    #[tokio::test]
+    async fn retweet_uses_original_interstitial() {
+        let results = hydrate(
+            HashMap::from([(10, allow()), (20, interstitial())]),
+            &[PostCandidate {
+                tweet_id: 10,
+                retweeted_tweet_id: Some(20),
+                in_network: Some(true),
+                ..Default::default()
+            }],
+        )
+        .await;
+        let hydrated = results[0].as_ref().unwrap();
+        assert!(matches!(
+            hydrated.visibility_reason,
+            Some(FilteredReason::SafetyResult(ref s)) if s.action == Action::Interstitial
+        ));
+        assert_eq!(hydrated.drop_ancillary_posts, Some(false));
+    }
+
+    #[tokio::test]
+    async fn wrapper_interstitial_is_not_the_primary() {
+        let results = hydrate(
+            HashMap::from([(10, interstitial())]),
+            &[PostCandidate {
+                tweet_id: 10,
+                retweeted_tweet_id: Some(20),
+                in_network: Some(true),
+                ..Default::default()
+            }],
+        )
+        .await;
+        let hydrated = results[0].as_ref().unwrap();
+        assert_eq!(hydrated.visibility_reason, None);
+    }
+
+    #[tokio::test]
+    async fn original_drop_still_ancillary_drops() {
+        let results = hydrate(
+            HashMap::from([(10, allow()), (20, drop_reason())]),
+            &[PostCandidate {
+                tweet_id: 10,
+                retweeted_tweet_id: Some(20),
+                in_network: Some(true),
+                ..Default::default()
+            }],
+        )
+        .await;
+        let hydrated = results[0].as_ref().unwrap();
+        assert!(matches!(
+            hydrated.visibility_reason,
+            Some(FilteredReason::SafetyResult(ref s)) if matches!(s.action, Action::Drop(_))
+        ));
+        assert_eq!(hydrated.drop_ancillary_posts, Some(true));
     }
 }

--- a/home-mixer/candidate_hydrators/vf_following_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/vf_following_candidate_hydrator.rs
@@ -1,4 +1,4 @@
-use crate::candidate_hydrators::vf_candidate_hydrator::should_drop_ancillary;
+use crate::candidate_hydrators::vf_candidate_hydrator::{primary_vf_id, should_drop_ancillary};
 use crate::models::candidate::PostCandidate;
 use crate::models::query::ScoredPostsQuery;
 use crate::params::EnableXaiVfClient;
@@ -70,7 +70,7 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for VFFollowingCandidateHydrator 
 
         let mut hydrated_candidates = Vec::with_capacity(candidates.len());
         for candidate in candidates {
-            let primary_result = all_results.get(&candidate.tweet_id);
+            let primary_result = all_results.get(&primary_vf_id(candidate));
             let visibility_reason = match primary_result {
                 Some(Ok(Some(reason))) => Some(reason.clone()),
                 _ => None,
@@ -94,5 +94,103 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for VFFollowingCandidateHydrator 
     fn update(&self, candidate: &mut PostCandidate, hydrated: PostCandidate) {
         candidate.visibility_reason = hydrated.visibility_reason;
         candidate.drop_ancillary_posts = hydrated.drop_ancillary_posts;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_safety_label_store::types::SafetyLabelMap;
+    use xai_twittercontext_proto::TwitterContextViewer;
+    use xai_visibility_filtering::models::{Action, SafetyResult, SafetyResultReason};
+    use xai_visibility_filtering::vf_client::{SafetyLevel, TweetVisibility};
+
+    struct MapClient {
+        results: HashMap<u64, FilteredReason>,
+    }
+
+    fn vis(reason: FilteredReason) -> TweetVisibility {
+        TweetVisibility {
+            reason: Some(reason),
+            safety_labels: Ok(SafetyLabelMap::default()),
+        }
+    }
+
+    fn interstitial() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: Some(SafetyResultReason::NsfwHighPrecision),
+            action: Action::Interstitial,
+        })
+    }
+
+    fn allow() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: None,
+            action: Action::Allow,
+        })
+    }
+
+    #[async_trait]
+    impl VfClient for MapClient {
+        async fn get_result(
+            &self,
+            post_ids: Vec<u64>,
+            _safety_level: SafetyLevel,
+            _for_user_id: u64,
+            _context: Option<TwitterContextViewer>,
+        ) -> HashMap<u64, Result<TweetVisibility>> {
+            post_ids
+                .into_iter()
+                .filter_map(|id| {
+                    self.results
+                        .get(&id)
+                        .cloned()
+                        .map(|reason| (id, Ok(vis(reason))))
+                })
+                .collect()
+        }
+    }
+
+    fn hydrator(results: HashMap<u64, FilteredReason>) -> VFFollowingCandidateHydrator {
+        let client = Arc::new(MapClient { results });
+        VFFollowingCandidateHydrator::new(client.clone(), client)
+    }
+
+    #[tokio::test]
+    async fn native_post_still_uses_its_own_id() {
+        let results = hydrator(HashMap::from([(20, interstitial())]))
+            .hydrate(
+                &ScoredPostsQuery::default(),
+                &[PostCandidate {
+                    tweet_id: 20,
+                    ..Default::default()
+                }],
+            )
+            .await;
+        let hydrated = results[0].as_ref().unwrap();
+        assert!(matches!(
+            hydrated.visibility_reason,
+            Some(FilteredReason::SafetyResult(ref s)) if s.action == Action::Interstitial
+        ));
+    }
+
+    #[tokio::test]
+    async fn retweet_uses_original_interstitial() {
+        let results = hydrator(HashMap::from([(10, allow()), (20, interstitial())]))
+            .hydrate(
+                &ScoredPostsQuery::default(),
+                &[PostCandidate {
+                    tweet_id: 10,
+                    retweeted_tweet_id: Some(20),
+                    ..Default::default()
+                }],
+            )
+            .await;
+        let hydrated = results[0].as_ref().unwrap();
+        assert!(matches!(
+            hydrated.visibility_reason,
+            Some(FilteredReason::SafetyResult(ref s)) if s.action == Action::Interstitial
+        ));
+        assert_eq!(hydrated.drop_ancillary_posts, Some(false));
     }
 }


### PR DESCRIPTION
## Bug

Phoenix `VFCandidateHydrator` and Following `VFFollowingCandidateHydrator` fetch the retweet original, then stamp `visibility_reason` from the wrapper id.

The original is already in the VF map: For You pushes `retweeted_tweet_id` into the TimelineHome batch; Following pushes it into the same Home batch. Lookup is `all_results.get(&candidate.tweet_id)`.

TimelineHome NSFW-high-precision is Interstitial, not Drop. `VFFilter` only hard-drops `Action::Drop`. `should_drop_ancillary` also ignores Interstitial. The original verdict never reaches the card.

OON retweets are already dropped by `OONRetweetReplyFilter`. This path is a followed-user retweet of an interstitial original.

- Entry: `VFCandidateHydrator` / `VFFollowingCandidateHydrator` (both already fetch the original)
- Sink: `visibility_reason` forwarded on the scored post (`scored_posts_server.rs`); `VFFilter` keeps Interstitial
- Break: primary lookup keyed by wrapper `tweet_id` instead of `retweeted_tweet_id.unwrap_or(tweet_id)`
- Viewer effect: in-network retweet of NSFW / gore original serves with no sensitive-media interstitial
- Twin: `AdsBrandSafetyVfHydrator` primary_id is already `retweeted_tweet_id.unwrap_or(tweet_id)`

This is not PR 55 / 90 (Home vs Recs merge). This is not PR 115 (Following quotes at Recs). This is not PR 116 (OON RT originals at Recs; those wrappers are dropped before VF). This is not PR 118 (QuoteHydrator TES key).

## Fix

Look up the primary VF verdict with `primary_vf_id` = original tweet id. Native posts unchanged. Ancillary Drop on the original is unchanged.

## Tests

- Native post still uses its own id
- Retweet of an Interstitial original stamps Interstitial (fails on unmodified main)
- Wrapper-only Interstitial is not used as the primary
- Original Drop still ancillary-drops

cargo: cannot run. Public dump has no Home Mixer manifest.
