### PR TITLE
Stop topic retrieval from fail-opening on Sports, Science, and Technology

### DIFF
--- a/phoenix/xrex/inference/serving_filters_runner.py
+++ b/phoenix/xrex/inference/serving_filters_runner.py
@@ -31,8 +31,8 @@ from xrex.models.recsys_two_tower_serving_filters import forward_with_filters
 from xrex.models.sharding_context import make_legacy_sharding_context
 from xrex.models.topic_categories import (
     NUM_TOPIC_INT32S,
-    TOPIC_ID_TO_BITS,
     bitmaps_to_int32_array,
+    build_request_topic_bitmasks,
     topic_ids_to_bitmap,
 )
 from xrex.train.trainer import RecsysTwoTowerModelConfig, TrainerContext
@@ -128,7 +128,7 @@ class FilteredRetrievalModelRunner(RetrievalModelRunner):
         if not new_bitmaps:
             logger.warning(
                 "No topic bitmaps loaded from any parquet file; "
-                "topic filtering will silently pass through all candidates."
+                "topic requests will match nothing instead of passing through."
             )
         self._all_topic_bitmaps = new_bitmaps
 
@@ -351,18 +351,10 @@ class FilteredRetrievalModelRunner(RetrievalModelRunner):
                 topic_bitmaps = jnp.zeros((N, NUM_TOPIC_INT32S), dtype=jnp.int32)
 
             batch_size = batch["user_hashes"].shape[0]
-            if request is not None and self._all_topic_bitmaps:
-                topic_entity_id_list = request.get_topic_entity_ids()
-                raw_bitmasks = [0] * batch_size
-                for i, tids in enumerate(topic_entity_id_list):
-                    if i >= batch_size:
-                        break
-                    mask = 0
-                    for tid in tids:
-                        if tid != 0 and tid in TOPIC_ID_TO_BITS:
-                            for bit in TOPIC_ID_TO_BITS[tid]:
-                                mask |= 1 << bit
-                    raw_bitmasks[i] = mask
+            if request is not None:
+                raw_bitmasks = build_request_topic_bitmasks(
+                    request.get_topic_entity_ids(), batch_size
+                )
                 topic_user_bitmasks = jnp.array(
                     bitmaps_to_int32_array(raw_bitmasks), dtype=jnp.int32
                 )

--- a/phoenix/xrex/models/test_topic_categories.py
+++ b/phoenix/xrex/models/test_topic_categories.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 X.AI Corp.
+"""Topic retrieval must not fail-open on production parent topic IDs."""
+
+from xrex.models.topic_categories import (
+    TOPIC_ID_TO_BITS,
+    _POST_SIDE_GROUP_MEMBERS,
+    build_request_topic_bitmasks,
+    request_topic_ids_to_bitmap,
+    topic_ids_to_bitmap,
+)
+
+# grok_topics.rs / TopicIdExpansion production parent IDs.
+TOPIC_SPORTS = 1925949452197478400
+TOPIC_TECHNOLOGY = 1925949722688126976
+TOPIC_SCIENCE = 1925949744683114496
+TOPIC_ATHLETICS = 1925950838414942210
+TOPIC_MUSIC = 1925949604224196608
+SPORTS_GROUP = 1000000000000000004
+SCIENCE_TECHNOLOGY_GROUP = 1000000000000000001
+
+
+def test_parent_topic_ids_are_only_on_the_post_side_map():
+    for tid in (TOPIC_SPORTS, TOPIC_SCIENCE, TOPIC_TECHNOLOGY, TOPIC_ATHLETICS):
+        assert tid not in TOPIC_ID_TO_BITS
+        assert tid in _POST_SIDE_GROUP_MEMBERS
+
+
+def test_request_mask_is_nonzero_for_sports_science_technology():
+    for tid in (TOPIC_SPORTS, TOPIC_SCIENCE, TOPIC_TECHNOLOGY, TOPIC_ATHLETICS):
+        mask = request_topic_ids_to_bitmap([tid])
+        assert mask != 0, f"{tid} must not fail-open as a zero user mask"
+
+
+def test_request_mask_matches_post_mask_for_parent_ids():
+    for tid in (TOPIC_SPORTS, TOPIC_SCIENCE, TOPIC_TECHNOLOGY, TOPIC_ATHLETICS):
+        assert request_topic_ids_to_bitmap([tid]) == topic_ids_to_bitmap([tid])
+
+
+def test_sports_request_overlaps_sports_post_not_science():
+    sports_req = request_topic_ids_to_bitmap([TOPIC_SPORTS])
+    sports_post = topic_ids_to_bitmap([TOPIC_SPORTS])
+    science_post = topic_ids_to_bitmap([TOPIC_SCIENCE])
+    assert sports_req & sports_post
+    assert not (sports_req & science_post)
+
+
+def test_science_request_overlaps_science_and_technology_group():
+    science_req = request_topic_ids_to_bitmap([TOPIC_SCIENCE])
+    tech_req = request_topic_ids_to_bitmap([TOPIC_TECHNOLOGY])
+    group_post = topic_ids_to_bitmap([SCIENCE_TECHNOLOGY_GROUP])
+    assert science_req & group_post
+    assert tech_req & group_post
+    assert science_req & tech_req
+
+
+def test_empty_or_zero_ids_stay_passthrough():
+    assert request_topic_ids_to_bitmap([]) == 0
+    assert request_topic_ids_to_bitmap(None) == 0
+    assert request_topic_ids_to_bitmap([0]) == 0
+    assert request_topic_ids_to_bitmap([0, 0]) == 0
+
+
+def test_known_leaf_and_group_ids_still_set_bits():
+    assert request_topic_ids_to_bitmap([TOPIC_MUSIC]) != 0
+    assert request_topic_ids_to_bitmap([SPORTS_GROUP]) != 0
+    assert request_topic_ids_to_bitmap([SPORTS_GROUP]) & topic_ids_to_bitmap([TOPIC_SPORTS])
+
+
+def test_build_request_topic_bitmasks_pads_and_truncates():
+    padded = build_request_topic_bitmasks([[TOPIC_SPORTS]], 3)
+    assert len(padded) == 3
+    assert padded[0] == request_topic_ids_to_bitmap([TOPIC_SPORTS])
+    assert padded[1] == 0
+    assert padded[2] == 0
+
+    truncated = build_request_topic_bitmasks(
+        [[TOPIC_SPORTS], [TOPIC_SCIENCE], [TOPIC_MUSIC]], 1
+    )
+    assert truncated == [request_topic_ids_to_bitmap([TOPIC_SPORTS])]
+
+
+def test_build_request_topic_bitmasks_empty_request_is_passthrough():
+    assert build_request_topic_bitmasks(None, 2) == [0, 0]
+    assert build_request_topic_bitmasks([], 2) == [0, 0]
+    assert build_request_topic_bitmasks([[], [0]], 2) == [0, 0]
+
+
+def test_topic_ids_only_lookup_would_fail_open_on_parents():
+    """Document the old serving path: TOPIC_ID_TO_BITS-only → mask 0 → leak organic."""
+    for tid in (TOPIC_SPORTS, TOPIC_SCIENCE, TOPIC_TECHNOLOGY, TOPIC_ATHLETICS):
+        old_mask = 0
+        if tid in TOPIC_ID_TO_BITS:
+            for bit in TOPIC_ID_TO_BITS[tid]:
+                old_mask |= 1 << bit
+        assert old_mask == 0
+        assert request_topic_ids_to_bitmap([tid]) != 0

--- a/phoenix/xrex/models/topic_categories.py
+++ b/phoenix/xrex/models/topic_categories.py
@@ -157,11 +157,38 @@ def topic_ids_to_bitmap(topic_entity_ids: list[int] | None) -> int:
         return 0
     bitmap = 0
     for topic_id in topic_entity_ids:
+        if topic_id == 0:
+            continue
         for bit in TOPIC_ID_TO_BITS.get(topic_id, ()):
             bitmap |= 1 << bit
         for bit in _POST_SIDE_GROUP_MEMBERS.get(topic_id, ()):
             bitmap |= 1 << bit
     return bitmap
+
+
+def request_topic_ids_to_bitmap(topic_entity_ids: list[int] | None) -> int:
+    """User-side topic mask. Same ID→bit map as posts.
+
+    Sports / Science / Technology parent IDs (and a few siblings) live only in
+    `_POST_SIDE_GROUP_MEMBERS`. A `TOPIC_ID_TO_BITS`-only lookup yields 0, and
+    serving treats a zero user mask as "no topic filter" — unfiltered organic
+    candidates leak into topic retrieval.
+    """
+    return topic_ids_to_bitmap(topic_entity_ids)
+
+
+def build_request_topic_bitmasks(
+    topic_entity_id_lists: list[list[int]] | None, batch_size: int
+) -> list[int]:
+    """Per-row user masks for a retrieval batch, padded or truncated to batch_size."""
+    masks = [0] * batch_size
+    if not topic_entity_id_lists:
+        return masks
+    for i, tids in enumerate(topic_entity_id_lists):
+        if i >= batch_size:
+            break
+        masks[i] = request_topic_ids_to_bitmap(tids)
+    return masks
 
 
 def bitmaps_to_int32_array(bitmaps: list[int]) -> npt.NDArray[np.int32]:


### PR DESCRIPTION
## Problem

Topic retrieval builds a user-side topic bitmask, then treats a zero mask as "no filter". For You correctly sends no topic IDs.

`PhoenixTopicsSource` sends production parent IDs (`TOPIC_SPORTS`, `TOPIC_SCIENCE`, `TOPIC_TECHNOLOGY`). Those IDs live only on the post-side map. The request path looked up `TOPIC_ID_TO_BITS` only, so the user mask stayed 0 and serving returned unfiltered organic candidates on those topic pages.

The same fail-open happened when topic bitmap parquet failed to load.

## Change

Use the same ID-to-bit map on the request as on posts. If topic bitmaps are missing, topic requests match nothing. For You (empty topic IDs) still passes through.

No ranking weights, no topic taxonomy rewrite.

## Tests

`phoenix/xrex/models/test_topic_categories.py` — 10 passed.