### PR TITLE
home-mixer: ignore expired safety labels in ads brand safety

### DIFF
--- a/home-mixer/candidate_hydrators/ads_brand_safety_vf_hydrator.rs
+++ b/home-mixer/candidate_hydrators/ads_brand_safety_vf_hydrator.rs
@@ -1,6 +1,6 @@
 use crate::models::brand_safety::{
     botmaker_rule_category, botmaker_rule_id_from, compute_verdict, compute_verdict_v2,
-    truncate_description, worst_verdict, BrandSafetyVerdict,
+    is_active_label, truncate_description, worst_verdict, BrandSafetyVerdict,
 };
 use crate::models::candidate::{PostCandidate, SafetyLabelInfo};
 use crate::models::query::ScoredPostsQuery;
@@ -20,11 +20,14 @@ pub struct AdsBrandSafetyVfHydrator {
 }
 
 fn to_safety_label_infos(labels: &SafetyLabelMap) -> impl Iterator<Item = SafetyLabelInfo> {
-    labels.iter().map(|(k, v)| SafetyLabelInfo {
-        label_type: *k,
-        description: v.source.as_deref().map(truncate_description),
-        source: botmaker_rule_id_from(v).map(|id| botmaker_rule_category(id).to_string()),
-    })
+    labels
+        .iter()
+        .filter(|(_, v)| is_active_label(v))
+        .map(|(k, v)| SafetyLabelInfo {
+            label_type: *k,
+            description: v.source.as_deref().map(truncate_description),
+            source: botmaker_rule_id_from(v).map(|id| botmaker_rule_category(id).to_string()),
+        })
 }
 
 #[async_trait]
@@ -534,5 +537,81 @@ mod tests {
             hydrated.brand_safety_verdict,
             Some(BrandSafetyVerdict::Safe)
         );
+    }
+
+    #[tokio::test]
+    async fn expired_community_note_does_not_keep_medium_risk() {
+        let mut labels: SafetyLabelMap = HashMap::new();
+        labels.insert(SafetyLabelType::GROK_SFA, SafetyLabel::default());
+        labels.insert(
+            SafetyLabelType::NSFA_COMMUNITY_NOTE,
+            SafetyLabel {
+                expires_at_msec: Some(1),
+                ..Default::default()
+            },
+        );
+        let client = Arc::new(FakeVfClient {
+            batch: SafetyLabelsBatch {
+                labels: HashMap::from([(1, labels)]),
+                failures: HashMap::new(),
+            },
+        });
+        let hydrator = AdsBrandSafetyVfHydrator { client };
+        let candidates = vec![PostCandidate {
+            tweet_id: 1,
+            ..Default::default()
+        }];
+
+        let results = hydrator
+            .hydrate(&ScoredPostsQuery::default(), &candidates)
+            .await;
+
+        let hydrated = results[0].as_ref().unwrap();
+        assert_eq!(
+            hydrated.brand_safety_verdict,
+            Some(BrandSafetyVerdict::Safe)
+        );
+        assert!(!hydrated
+            .safety_labels
+            .iter()
+            .any(|l| l.label_type == SafetyLabelType::NSFA_COMMUNITY_NOTE));
+    }
+
+    #[tokio::test]
+    async fn active_community_note_is_medium_risk_and_listed() {
+        let mut labels: SafetyLabelMap = HashMap::new();
+        labels.insert(SafetyLabelType::GROK_SFA, SafetyLabel::default());
+        labels.insert(
+            SafetyLabelType::NSFA_COMMUNITY_NOTE,
+            SafetyLabel {
+                expires_at_msec: Some(i64::MAX),
+                ..Default::default()
+            },
+        );
+        let client = Arc::new(FakeVfClient {
+            batch: SafetyLabelsBatch {
+                labels: HashMap::from([(1, labels)]),
+                failures: HashMap::new(),
+            },
+        });
+        let hydrator = AdsBrandSafetyVfHydrator { client };
+        let candidates = vec![PostCandidate {
+            tweet_id: 1,
+            ..Default::default()
+        }];
+
+        let results = hydrator
+            .hydrate(&ScoredPostsQuery::default(), &candidates)
+            .await;
+
+        let hydrated = results[0].as_ref().unwrap();
+        assert_eq!(
+            hydrated.brand_safety_verdict,
+            Some(BrandSafetyVerdict::MediumRisk)
+        );
+        assert!(hydrated
+            .safety_labels
+            .iter()
+            .any(|l| l.label_type == SafetyLabelType::NSFA_COMMUNITY_NOTE));
     }
 }

--- a/home-mixer/models/brand_safety.rs
+++ b/home-mixer/models/brand_safety.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
 use xai_x_thrift::tweet_safety_label::{SafetyLabel, SafetyLabelSource, SafetyLabelType};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -42,29 +43,79 @@ pub(crate) const LOW_RISK_LABELS: &[SafetyLabelType] = &[
 
 const PTOS_CUTOFF_TWEET_ID: u64 = 2_054_275_414_225_846_272;
 
+fn now_msec() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+// GetSafetyLabels returns expired rows. VF drop rules already skip them.
+// Ads adjacency still used type presence, so a lapsed Community Note
+// (or any other TTL label) kept the post MediumRisk / HighRisk.
+fn is_unexpired(label: &SafetyLabel, now_msec: i64) -> bool {
+    match label.expires_at_msec {
+        Some(exp) if exp <= now_msec => false,
+        _ => true,
+    }
+}
+
+fn has_active(
+    labels: &HashMap<SafetyLabelType, SafetyLabel>,
+    label_type: SafetyLabelType,
+    now_msec: i64,
+) -> bool {
+    labels
+        .get(&label_type)
+        .is_some_and(|label| is_unexpired(label, now_msec))
+}
+
+pub(crate) fn is_active_label(label: &SafetyLabel) -> bool {
+    is_unexpired(label, now_msec())
+}
+
 pub fn compute_verdict(
     labels: &HashMap<SafetyLabelType, SafetyLabel>,
     tweet_id: u64,
 ) -> BrandSafetyVerdict {
-    if HIGH_RISK_LABELS.iter().any(|l| labels.contains_key(l)) {
+    compute_verdict_at(labels, tweet_id, now_msec())
+}
+
+fn compute_verdict_at(
+    labels: &HashMap<SafetyLabelType, SafetyLabel>,
+    tweet_id: u64,
+    now_msec: i64,
+) -> BrandSafetyVerdict {
+    if HIGH_RISK_LABELS
+        .iter()
+        .any(|l| has_active(labels, *l, now_msec))
+    {
         return BrandSafetyVerdict::HighRisk;
     }
 
-    if MEDIUM_RISK_LABELS.iter().any(|l| labels.contains_key(l)) {
+    if MEDIUM_RISK_LABELS
+        .iter()
+        .any(|l| has_active(labels, *l, now_msec))
+    {
         return BrandSafetyVerdict::MediumRisk;
     }
 
-    let scored_by_grok = labels.contains_key(&SafetyLabelType::GROK_SFA)
-        || labels.contains_key(&SafetyLabelType::GROK_NSFA_LIMITED);
+    let scored_by_grok = has_active(labels, SafetyLabelType::GROK_SFA, now_msec)
+        || has_active(labels, SafetyLabelType::GROK_NSFA_LIMITED, now_msec);
     if !scored_by_grok {
         return BrandSafetyVerdict::MediumRisk;
     }
 
-    if tweet_id >= PTOS_CUTOFF_TWEET_ID && !labels.contains_key(&SafetyLabelType::PTOS_REVIEWED) {
+    if tweet_id >= PTOS_CUTOFF_TWEET_ID
+        && !has_active(labels, SafetyLabelType::PTOS_REVIEWED, now_msec)
+    {
         return BrandSafetyVerdict::MediumRisk;
     }
 
-    if LOW_RISK_LABELS.iter().any(|l| labels.contains_key(l)) {
+    if LOW_RISK_LABELS
+        .iter()
+        .any(|l| has_active(labels, *l, now_msec))
+    {
         return BrandSafetyVerdict::LowRisk;
     }
 
@@ -100,27 +151,49 @@ pub(crate) fn compute_verdict_v2(
     labels: &HashMap<SafetyLabelType, SafetyLabel>,
     tweet_id: u64,
 ) -> BrandSafetyVerdict {
-    if !V2_WRITTEN_LABELS.iter().any(|l| labels.contains_key(l)) {
-        return compute_verdict(labels, tweet_id);
+    compute_verdict_v2_at(labels, tweet_id, now_msec())
+}
+
+fn compute_verdict_v2_at(
+    labels: &HashMap<SafetyLabelType, SafetyLabel>,
+    tweet_id: u64,
+    now_msec: i64,
+) -> BrandSafetyVerdict {
+    if !V2_WRITTEN_LABELS
+        .iter()
+        .any(|l| has_active(labels, *l, now_msec))
+    {
+        return compute_verdict_at(labels, tweet_id, now_msec);
     }
-    if HIGH_RISK_LABELS.iter().any(|l| labels.contains_key(l)) {
+    if HIGH_RISK_LABELS
+        .iter()
+        .any(|l| has_active(labels, *l, now_msec))
+    {
         return BrandSafetyVerdict::HighRisk;
     }
-    if MEDIUM_RISK_LABELS_V2.iter().any(|l| labels.contains_key(l)) {
+    if MEDIUM_RISK_LABELS_V2
+        .iter()
+        .any(|l| has_active(labels, *l, now_msec))
+    {
         return BrandSafetyVerdict::MediumRisk;
     }
 
-    let scored_by_grok = labels.contains_key(&SafetyLabelType::GROK_SFA_V2)
-        || labels.contains_key(&SafetyLabelType::GROK_NSFA_LIMITED_V2);
+    let scored_by_grok = has_active(labels, SafetyLabelType::GROK_SFA_V2, now_msec)
+        || has_active(labels, SafetyLabelType::GROK_NSFA_LIMITED_V2, now_msec);
     if !scored_by_grok {
         return BrandSafetyVerdict::MediumRisk;
     }
 
-    if tweet_id >= PTOS_CUTOFF_TWEET_ID && !labels.contains_key(&SafetyLabelType::PTOS_REVIEWED) {
+    if tweet_id >= PTOS_CUTOFF_TWEET_ID
+        && !has_active(labels, SafetyLabelType::PTOS_REVIEWED, now_msec)
+    {
         return BrandSafetyVerdict::MediumRisk;
     }
 
-    if LOW_RISK_LABELS_V2.iter().any(|l| labels.contains_key(l)) {
+    if LOW_RISK_LABELS_V2
+        .iter()
+        .any(|l| has_active(labels, *l, now_msec))
+    {
         return BrandSafetyVerdict::LowRisk;
     }
 
@@ -433,6 +506,141 @@ mod tests {
         );
         assert_eq!(
             worst_verdict(&BrandSafetyVerdict::MediumRisk, &BrandSafetyVerdict::Safe),
+            BrandSafetyVerdict::MediumRisk
+        );
+    }
+
+    fn label_with_expiry(expires_at_msec: Option<i64>) -> SafetyLabel {
+        SafetyLabel {
+            expires_at_msec,
+            ..Default::default()
+        }
+    }
+
+    fn labels_with_expiry(
+        types: &[(SafetyLabelType, Option<i64>)],
+    ) -> HashMap<SafetyLabelType, SafetyLabel> {
+        types
+            .iter()
+            .map(|(t, exp)| (*t, label_with_expiry(*exp)))
+            .collect()
+    }
+
+    #[test]
+    fn expired_community_note_does_not_keep_medium_risk() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::NSFA_COMMUNITY_NOTE, Some(999)),
+        ]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::Safe
+        );
+    }
+
+    #[test]
+    fn future_community_note_is_still_medium_risk() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::NSFA_COMMUNITY_NOTE, Some(2_000)),
+        ]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::MediumRisk
+        );
+    }
+
+    #[test]
+    fn missing_expiry_on_community_note_is_treated_as_permanent() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::NSFA_COMMUNITY_NOTE, None),
+        ]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::MediumRisk
+        );
+    }
+
+    #[test]
+    fn expiry_exactly_now_is_not_treated_as_active() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::NSFA_COMMUNITY_NOTE, Some(1_000)),
+        ]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::Safe
+        );
+    }
+
+    #[test]
+    fn expired_sibling_does_not_hide_an_active_medium_risk_label() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::NSFA_COMMUNITY_NOTE, Some(500)),
+            (SafetyLabelType::NSFW_TEXT, Some(2_000)),
+        ]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::MediumRisk
+        );
+    }
+
+    #[test]
+    fn expired_high_risk_label_does_not_keep_high_risk() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::NSFW_HIGH_PRECISION, Some(999)),
+        ]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::Safe
+        );
+    }
+
+    #[test]
+    fn expired_low_risk_label_does_not_keep_low_risk() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::NSFA_LIMITED_INVENTORY, Some(999)),
+        ]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::Safe
+        );
+    }
+
+    #[test]
+    fn expired_grok_sfa_is_treated_as_unscored() {
+        let labels = labels_with_expiry(&[(SafetyLabelType::GROK_SFA, Some(999))]);
+        assert_eq!(
+            compute_verdict_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::MediumRisk
+        );
+    }
+
+    #[test]
+    fn v2_expired_community_note_does_not_keep_medium_risk() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA_V2, None),
+            (SafetyLabelType::NSFA_COMMUNITY_NOTE, Some(999)),
+        ]);
+        assert_eq!(
+            compute_verdict_v2_at(&labels, PRE_CUTOFF_ID, 1_000),
+            BrandSafetyVerdict::Safe
+        );
+    }
+
+    #[test]
+    fn v2_expired_written_labels_fall_back_to_v1() {
+        let labels = labels_with_expiry(&[
+            (SafetyLabelType::GROK_SFA, None),
+            (SafetyLabelType::GROK_SFA_V2, Some(999)),
+            (SafetyLabelType::NSFA_COMMUNITY_NOTE, None),
+        ]);
+        assert_eq!(
+            compute_verdict_v2_at(&labels, PRE_CUTOFF_ID, 1_000),
             BrandSafetyVerdict::MediumRisk
         );
     }


### PR DESCRIPTION
## Bug
GetSafetyLabels still returns expired rows. VF drop rules already skip them (PR 106). Ads brand safety did not.

`AdsBrandSafetyVfHydrator` calls `compute_verdict` / `compute_verdict_v2`, which used type presence only. A lapsed `NSFA_COMMUNITY_NOTE` (or any other TTL label in the high/medium/low-risk sets) kept the post HighRisk or MediumRisk. Ads blender then treats those verdicts as avoid, so ads would not sit next to a post whose note or label had already expired.

Community Notes have no VF drop rule in this dump. Ads adjacency is the ranking sink for `NSFA_COMMUNITY_NOTE`.

## Fix
Skip labels whose `expires_at_msec` is at or before now before scoring v1 and v2 verdicts, and before listing labels on the scored post. A missing expiry stays permanent. Expired v2 written labels fall back to v1.

No change to write paths, TTLs, GetSafetyLabels, or VF drop rules.

## Proof
- Entry: `AdsBrandSafetyVfHydrator` → `compute_verdict` / `compute_verdict_v2`
- Sink: ads blender avoid on HighRisk / MediumRisk
- Break: type presence ignored `expires_at_msec`; GetSafetyLabels returns expired rows
- Viewer effect: post with an expired Community Note (or other TTL label) still blocked ads next to it
- Twin: VF `from_proto_label_types` expiry fence (PR 106)

## Tests
- `expired_community_note_does_not_keep_medium_risk` (fails on unmodified main)
- future / missing / exactly-now expiry
- expired sibling does not hide an active medium-risk label
- expired high-risk and low-risk labels drop their tier
- expired GROK_SFA treated as unscored
- v2: expired note is Safe; expired v2 written labels fall back to v1
- hydrator: expired note omitted from `safety_labels`; active note still MediumRisk

`cargo test` cannot run in the public dump (no Home Mixer Cargo.toml). Decision table for the expiry fence was run standalone and matched these cases.

## Fork
Same fix on the older fork tree (no HighRisk / v2): https://github.com/Pitchfork-and-Torch/x-algorithm/pull/13

This is a port onto current `xai-org/x-algorithm` `main` rather than a clean cherry-pick.