### PR TITLE
Limit Brazil 2026 election filter to BR request country

### DIFF
--- a/home-mixer/filters/brazil_2026_election_filter.rs
+++ b/home-mixer/filters/brazil_2026_election_filter.rs
@@ -5218,14 +5218,33 @@ impl Brazil2026ElectionFilter {
         // (ancestors are returned on the scored post for For You thread UI).
         candidate.ancestor_users.iter().copied().any(is_excluded)
     }
+
+    /// Art. 28 § 1º-A applies to recommendation for users in Brazil.
+    /// Unknown / empty request country stays in scope so a missing geo
+    /// header cannot disable the list. A known non-BR country does not.
+    fn applies_to_viewer(query: &ScoredPostsQuery) -> bool {
+        let country = query.country_code.trim();
+        country.is_empty() || country.eq_ignore_ascii_case("br")
+    }
 }
 
 impl Filter<ScoredPostsQuery, PostCandidate> for Brazil2026ElectionFilter {
+    fn enable(&self, query: &ScoredPostsQuery) -> bool {
+        Self::applies_to_viewer(query)
+    }
+
     fn filter(
         &self,
         query: &ScoredPostsQuery,
         candidates: Vec<PostCandidate>,
     ) -> FilterResult<PostCandidate> {
+        if !Self::applies_to_viewer(query) {
+            return FilterResult {
+                kept: candidates,
+                removed: Vec::new(),
+            };
+        }
+
         let followed_user_ids: FxHashSet<u64> = query
             .user_features
             .followed_user_ids
@@ -5252,6 +5271,13 @@ mod tests {
         PostCandidate {
             tweet_id,
             author_id,
+            ..Default::default()
+        }
+    }
+
+    fn query_with_country(country_code: &str) -> ScoredPostsQuery {
+        ScoredPostsQuery {
+            country_code: country_code.to_string(),
             ..Default::default()
         }
     }
@@ -5412,5 +5438,58 @@ mod tests {
                 &no_follows
             ));
         }
+    }
+
+    #[test]
+    fn known_non_brazil_viewer_keeps_listed_authors() {
+        let filter = Brazil2026ElectionFilter;
+        let listed = SAMPLE_LISTED[0];
+        let query = query_with_country("US");
+        assert!(!Brazil2026ElectionFilter::applies_to_viewer(&query));
+
+        let result = filter.filter(&query, vec![make_candidate(1, listed)]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].author_id, listed);
+        assert!(result.removed.is_empty());
+    }
+
+    #[test]
+    fn brazil_viewer_still_drops_listed_authors() {
+        let filter = Brazil2026ElectionFilter;
+        let listed = SAMPLE_LISTED[0];
+        let query = query_with_country("BR");
+        assert!(Brazil2026ElectionFilter::applies_to_viewer(&query));
+
+        let result = filter.filter(&query, vec![make_candidate(1, 1), make_candidate(2, listed)]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 1);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].author_id, listed);
+    }
+
+    #[test]
+    fn lowercase_br_is_in_scope() {
+        assert!(Brazil2026ElectionFilter::applies_to_viewer(
+            &query_with_country("br")
+        ));
+    }
+
+    #[test]
+    fn unknown_country_fails_closed() {
+        let filter = Brazil2026ElectionFilter;
+        let listed = SAMPLE_LISTED[1];
+        let query = query_with_country("");
+        assert!(Brazil2026ElectionFilter::applies_to_viewer(&query));
+        assert!(Brazil2026ElectionFilter::applies_to_viewer(
+            &ScoredPostsQuery::default()
+        ));
+
+        let result = filter.filter(&query, vec![make_candidate(1, listed)]);
+
+        assert!(result.kept.is_empty());
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].author_id, listed);
     }
 }


### PR DESCRIPTION
## Bug

`Brazil2026ElectionFilter` runs for every For You viewer. It has no country check.

The list is the TSE 2026 Electoral Court set (Art. 28 § 1º-A of Resolution 23.610). That rule is for recommendation in Brazil. `query.country_code` is already on the request. The filter ignored it, so about 2554 listed accounts were dropped from For You worldwide.

Not the listed-viewer self-id hole (#53). `is_excluded_author` and the follow exception are unchanged.

## OON SimClusters NSFW gate (survey)

`OONNsfwSimclustersFilter` was checked after the gizmoduck origin NSFW change (#125).

- It does not look up an author id. It reads `nsfw_author`. After #125 that flag is the OR of poster, original, and quoted, and a store miss is labeled.
- `in_network == Some(false)` is the poster follow bit. That is correct. In-network NSFW is a VF interstitial, not a drop.
- `nsfw_author == Some(true)` fail-opens on `None`. On the live SimClusters path, gizmoduck is on and #125 always writes `Some`. Simclusters retrieval and gizmoduck both skip when `has_cached_posts`.
- VF OON already drops NSFW authors on originals. This extra gate is the mixer-side drop for OON SimClusters quotes of NSFW authors (VF scores the quoter). That is defense-in-depth / the #125 quote path. It was not removed.

No remaining correctness bug in that filter after #125.

## Fix

One file, `home-mixer/filters/brazil_2026_election_filter.rs`.

- Apply the list when `country_code` is `BR` / `br`.
- Apply the list when country is empty or missing (fail closed on unknown geo).
- Skip when country is present and not Brazil.

## Tests

- Known US viewer keeps a listed author.
- BR viewer still drops a listed author.
- `br` is in scope.
- Empty / default country still drops a listed author.

`home-mixer` has no public Cargo manifest. The geo gate was compiled and run as a rustc model: passed.

Lane: `home-mixer/filters/brazil_2026_election_filter.rs` only. Based on `xai-org/x-algorithm` main.