### PR TITLE
Stop CoreData from keeping a stale source author_id after TES

### DIFF
--- a/home-mixer/candidate_hydrators/core_data_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/core_data_candidate_hydrator.rs
@@ -118,15 +118,24 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for CoreDataCandidateHydrat
     }
 
     fn update(&self, candidate: &mut PostCandidate, hydrated: PostCandidate) {
-        if candidate.author_id == 0 && hydrated.author_id != 0 {
-            candidate.author_id = hydrated.author_id;
-        }
-        candidate.retweeted_user_id = hydrated.retweeted_user_id;
-        candidate.retweeted_tweet_id = hydrated.retweeted_tweet_id;
-        candidate.in_reply_to_tweet_id = hydrated.in_reply_to_tweet_id;
-        candidate.ancestor_users = hydrated.ancestor_users;
-        candidate.tweet_text = hydrated.tweet_text;
+        apply_tes_core_data(candidate, &hydrated);
     }
+}
+
+/// TES author wins when TES resolved one. Source author_id is kept only on TES miss.
+///
+/// #128 runs InNetwork after this write. A leftover fill-if-zero kept Phoenix /
+/// Thunder's nonzero author_id, so the stamp used a stale id and VF fetched
+/// Recs. NSFW HP / gore / card then hard-dropped (Home would interstitial).
+fn apply_tes_core_data(candidate: &mut PostCandidate, hydrated: &PostCandidate) {
+    if hydrated.author_id != 0 {
+        candidate.author_id = hydrated.author_id;
+    }
+    candidate.retweeted_user_id = hydrated.retweeted_user_id;
+    candidate.retweeted_tweet_id = hydrated.retweeted_tweet_id;
+    candidate.in_reply_to_tweet_id = hydrated.in_reply_to_tweet_id;
+    candidate.ancestor_users = hydrated.ancestor_users.clone();
+    candidate.tweet_text = hydrated.tweet_text.clone();
 }
 
 fn core_data_fetch_ids(candidates: &[PostCandidate]) -> Vec<u64> {
@@ -176,5 +185,116 @@ impl CoreDataCandidateHydrator {
             receiver.incr(metric_name.as_str(), &FOUND_SCOPE, hydrated_count as u64);
             receiver.incr(metric_name.as_str(), &MISSING_SCOPE, missing_count as u64);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::candidate_hydrators::in_network_candidate_hydrator::InNetworkCandidateHydrator;
+    use crate::models::user_features::UserFeatures;
+    use xai_candidate_pipeline::hydrator::Hydrator;
+
+    fn apply_tes_author(source_author: u64, tes_author: u64) -> u64 {
+        let mut candidate = PostCandidate {
+            tweet_id: 1,
+            author_id: source_author,
+            ..Default::default()
+        };
+        apply_tes_core_data(
+            &mut candidate,
+            &PostCandidate {
+                author_id: tes_author,
+                tweet_text: "tes".into(),
+                ..Default::default()
+            },
+        );
+        candidate.author_id
+    }
+
+    #[test]
+    fn tes_author_fills_zero_source() {
+        assert_eq!(apply_tes_author(0, 42), 42);
+    }
+
+    #[test]
+    fn tes_author_replaces_stale_nonzero_source() {
+        assert_eq!(
+            apply_tes_author(99, 42),
+            42,
+            "Phoenix/Thunder nonzero author must not block TES"
+        );
+    }
+
+    #[test]
+    fn tes_miss_keeps_source_author() {
+        assert_eq!(apply_tes_author(99, 0), 99);
+        assert_eq!(apply_tes_author(0, 0), 0);
+    }
+
+    #[tokio::test]
+    async fn tes_author_then_in_network_stamps_followed_home() {
+        // Residual after #128: CoreData runs first, but a stale source author
+        // used to survive TES. InNetwork then stamped OON and VF Recs-dropped
+        // NSFW HP / gore / card (Home would interstitial).
+        let tes_author = 42u64;
+        let stale_source = 99u64;
+        let author_id = apply_tes_author(stale_source, tes_author);
+        assert_eq!(author_id, tes_author);
+
+        let query = ScoredPostsQuery {
+            user_id: 1,
+            user_features: UserFeatures {
+                followed_user_ids: vec![tes_author as i64],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let hydrator = InNetworkCandidateHydrator;
+        let candidates = vec![PostCandidate {
+            tweet_id: 1,
+            author_id,
+            ..Default::default()
+        }];
+        let hydrated = hydrator.hydrate(&query, &candidates).await;
+        let mut candidate = candidates.into_iter().next().unwrap();
+        hydrator.update(
+            &mut candidate,
+            hydrated.into_iter().next().unwrap().unwrap(),
+        );
+        assert_eq!(
+            candidate.in_network,
+            Some(true),
+            "followed TES author must stamp Home, not Recs"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_source_author_used_to_stamp_oon() {
+        let query = ScoredPostsQuery {
+            user_id: 1,
+            user_features: UserFeatures {
+                followed_user_ids: vec![42],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let hydrator = InNetworkCandidateHydrator;
+        let candidates = vec![PostCandidate {
+            tweet_id: 1,
+            author_id: 99,
+            ..Default::default()
+        }];
+        let hydrated = hydrator.hydrate(&query, &candidates).await;
+        let mut candidate = candidates.into_iter().next().unwrap();
+        hydrator.update(
+            &mut candidate,
+            hydrated.into_iter().next().unwrap().unwrap(),
+        );
+        assert_eq!(
+            candidate.in_network,
+            Some(false),
+            "stale source author 99 is not followed"
+        );
     }
 }


### PR DESCRIPTION
## Bug

#128 runs InNetwork after CoreData so TES can fill `author_id`. CoreData `update` only wrote `author_id` when the source field was already 0.

Phoenix (and Thunder) ship a nonzero `author_id`. TES still runs (text is empty, so `already_hydrated` is false). The TES author is discarded. InNetwork stamps the source id.

A followed TES author is then fetched at `TimelineHomeRecommendations`. Recs-only Drop fires for tweet `NSFW_HIGH_PRECISION`, `GORE_AND_VIOLENCE_HIGH_PRECISION`, and `NSFW_CARD_IMAGE`. The same labels on Home are Interstitial (`NSFW_MEDIA_INTERSTITIALS`).

- Entry: `CoreDataCandidateHydrator::update` fill-if-zero
- Sink: `VFCandidateHydrator` (`in_network.unwrap_or(false)` → Recs) then `VFFilter`
- Break: TES author thrown away when the source already set a nonzero id
- Viewer effect: a followee's NSFW HP / gore / card post retrieved via Phoenix is hard-dropped on For You
- Twin: `retweeted_tweet_id` / `retweeted_user_id` from TES already overwrite the source

This is not rewriting Recs-only policy. This is not #128 (order). This is not #119 (RT wrapper primary id). This is not #115 (Following quotes).

## Fix

When TES returns a nonzero author, write it. TES miss still keeps the source author.

## Tests

- Source `author_id = 0`, TES `42` → `42`
- Source `99`, TES `42` → `42`
- TES miss (`0`) keeps source
- TES `42` (followed) then InNetwork → `in_network = true`
- Stale source `99` without TES overwrite still stamps OON

Standalone decision-table harness (same predicate): 6 assertions passed.

`cargo test` cannot run here. Public dump has no Home Mixer manifest.

## Leftover

`already_hydrated` still skips TES when source `author_id != 0` and text is nonempty. `InNetworkCandidateHydrator.enable` is still `!has_cached_posts`.