### PR TITLE
Fail closed when TES NSFW, takedown, nullcast, or media reads error

### DIFF
--- a/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
@@ -174,11 +174,15 @@ pub(crate) fn should_drop_ancillary(
     false
 }
 
+/// Hard-drop only. Interstitial on a quote / RT / ancestor is intentional
+/// keep-and-warn (Home NSFW rules emit Interstitial; Recs has Drop twins).
+/// Do not treat Interstitial as Drop here. TES flag misses that skip those
+/// rules are handled in visibility-filtering hydration (fail closed).
 fn should_drop_reason(reason: &FilteredReason) -> bool {
     match reason {
         FilteredReason::SafetyResult(safety_result) => {
             matches!(safety_result.action, Action::Drop(_))
         }
-        _ => true, 
+        _ => true,
     }
 }

--- a/visibility-filtering/hydration/batch.rs
+++ b/visibility-filtering/hydration/batch.rs
@@ -25,6 +25,10 @@ impl<V> Hydrated<V> {
             Hydrated::NotFound | Hydrated::Failed(_) => None,
         }
     }
+
+    pub(crate) fn is_failed(&self) -> bool {
+        matches!(self, Hydrated::Failed(_))
+    }
 }
 
 impl<V, E: Display> From<Result<Option<V>, E>> for Hydrated<V> {
@@ -194,12 +198,15 @@ mod tests {
 
         assert_eq!(batch.get(&1), Some(&7));
         assert_eq!(batch.hydrated(&2), Some(&Hydrated::NotFound));
+        assert!(!Hydrated::Found(7).is_failed());
+        assert!(!Hydrated::<u32>::NotFound.is_failed());
         assert_eq!(
             batch.hydrated(&3),
             Some(&Hydrated::Failed(HydrationError::Rpc(
                 "backend unavailable".into()
             )))
         );
+        assert!(batch.hydrated(&3).is_some_and(Hydrated::is_failed));
         assert_eq!(batch.get_or_default(&2), 0);
         assert_eq!(batch.get_or_default(&3), 0);
     }

--- a/visibility-filtering/hydration/mod.rs
+++ b/visibility-filtering/hydration/mod.rs
@@ -25,7 +25,7 @@ use safety_label_hydrator::{SafetyLabelHydration, SafetyLabelHydrator};
 use socialgraph_hydrator::SocialgraphHydrator;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tes_hydrator::TesHydrator;
+use tes_hydrator::{retain_candidates_with_usable_tes_flags, TesHydrator};
 use viewer_hydrator::ViewerHydrator;
 use xai_core_entities::gizmoduck_client::GizmoduckClient;
 use xai_core_entities::tweet_entity_service_client::TESClient;
@@ -207,6 +207,7 @@ impl HydrationPipeline {
                 label_response,
             } = safety_labels;
 
+            let candidates = retain_candidates_with_usable_tes_flags(candidates, &tes_tweet_keyed);
             let tweet_features = self.tes_hydrator.assemble_tweet_features(
                 &candidates,
                 &core_datas,

--- a/visibility-filtering/hydration/tes_hydrator.rs
+++ b/visibility-filtering/hydration/tes_hydrator.rs
@@ -1,4 +1,4 @@
-use crate::hydration::batch::TweetHydrationBatch;
+use crate::hydration::batch::{Hydrated, TweetHydrationBatch};
 use crate::hydration::metrics::{record_batch_size, timed_keyed_rpc, timed_results};
 use crate::models::{
     CoreFeature, MediaFeature, NsfwFeature, TweetCandidateInput, TweetFeatures, TweetId,
@@ -26,6 +26,37 @@ pub(crate) struct TweetHydration {
     pub(crate) takedown_reasons: TweetHydrationBatch<Vec<TakedownReason>>,
     pub(crate) edit_control: TweetHydrationBatch<EditControl>,
     pub(crate) media: TweetHydrationBatch<MediaFeature>,
+}
+
+impl TweetHydration {
+    /// TES flag RPCs that decide Drop / Interstitial. A Failed read must not
+    /// be treated as "flag unset" — that fail-opens NSFW, takedown, nullcast,
+    /// and DMCA/geo media rules. Genuine NotFound (no flag) is not Failed.
+    pub(crate) fn safety_lookup_failed(&self, id: TweetId) -> bool {
+        self.nsfw_user
+            .hydrated(&id)
+            .is_some_and(Hydrated::is_failed)
+            || self
+                .nsfw_admin
+                .hydrated(&id)
+                .is_some_and(Hydrated::is_failed)
+            || self
+                .takedown_reasons
+                .hydrated(&id)
+                .is_some_and(Hydrated::is_failed)
+            || self.nullcast.hydrated(&id).is_some_and(Hydrated::is_failed)
+            || self.media.hydrated(&id).is_some_and(Hydrated::is_failed)
+    }
+}
+
+pub(crate) fn retain_candidates_with_usable_tes_flags(
+    candidates: Vec<TweetCandidateInput>,
+    tweet_keyed: &TweetHydration,
+) -> Vec<TweetCandidateInput> {
+    candidates
+        .into_iter()
+        .filter(|c| !tweet_keyed.safety_lookup_failed(c.tweet_id))
+        .collect()
 }
 
 impl TesHydrator {
@@ -473,5 +504,101 @@ mod tests {
         let f = &features[&TweetId(10)];
         assert!(f.core.text.is_empty());
         assert!(!f.media.has_media);
+    }
+
+    fn failed_bool(id: u64) -> TweetHydrationBatch<bool> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(TweetId(id), Err::<Option<bool>, _>("tes unavailable"))]),
+        )
+    }
+
+    fn found_false(id: u64) -> TweetHydrationBatch<bool> {
+        found(id, false)
+    }
+
+    fn not_found_bool(id: u64) -> TweetHydrationBatch<bool> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(TweetId(id), Ok::<_, anyhow::Error>(None))]),
+        )
+    }
+
+    #[test]
+    fn safety_lookup_failed_is_false_when_flags_are_found_or_absent() {
+        let keyed = TweetHydration {
+            nsfw_user: found_false(10),
+            nsfw_admin: not_found_bool(10),
+            ..Default::default()
+        };
+
+        assert!(!keyed.safety_lookup_failed(TweetId(10)));
+        assert!(!TweetHydration::default().safety_lookup_failed(TweetId(10)));
+    }
+
+    #[test]
+    fn failed_nsfw_user_lookup_is_safety_failure() {
+        let keyed = TweetHydration {
+            nsfw_user: failed_bool(10),
+            ..Default::default()
+        };
+
+        assert!(keyed.safety_lookup_failed(TweetId(10)));
+        assert!(!keyed.safety_lookup_failed(TweetId(11)));
+    }
+
+    #[test]
+    fn failed_takedown_nullcast_or_media_lookup_is_safety_failure() {
+        let takedown = TweetHydration {
+            takedown_reasons: TweetHydrationBatch::from_results(
+                [TweetId(10)],
+                HashMap::from([(
+                    TweetId(10),
+                    Err::<Option<Vec<TakedownReason>>, _>("tes unavailable"),
+                )]),
+            ),
+            ..Default::default()
+        };
+        let nullcast = TweetHydration {
+            nullcast: failed_bool(10),
+            ..Default::default()
+        };
+        let media = TweetHydration {
+            media: TweetHydrationBatch::from_results(
+                [TweetId(10)],
+                HashMap::from([(
+                    TweetId(10),
+                    Err::<Option<MediaFeature>, _>("tes unavailable"),
+                )]),
+            ),
+            ..Default::default()
+        };
+
+        assert!(takedown.safety_lookup_failed(TweetId(10)));
+        assert!(nullcast.safety_lookup_failed(TweetId(10)));
+        assert!(media.safety_lookup_failed(TweetId(10)));
+    }
+
+    #[test]
+    fn retain_drops_only_ids_whose_safety_flag_rpc_failed() {
+        let keyed = TweetHydration {
+            nsfw_user: TweetHydrationBatch::from_results(
+                [TweetId(10), TweetId(11)],
+                HashMap::from([
+                    (TweetId(10), Err::<Option<bool>, _>("tes unavailable")),
+                    (TweetId(11), Ok::<_, anyhow::Error>(Some(false))),
+                ]),
+            ),
+            ..Default::default()
+        };
+        let kept = retain_candidates_with_usable_tes_flags(
+            vec![candidate(10, 100), candidate(11, 100)],
+            &keyed,
+        );
+
+        assert_eq!(
+            kept.iter().map(|c| c.tweet_id.0).collect::<Vec<_>>(),
+            vec![11]
+        );
     }
 }


### PR DESCRIPTION
## Wave 2 check

Quote / RT / ancestor `Action::Interstitial` does not set `drop_ancillary_posts`. Verified.

`should_drop_reason` only matches `Action::Drop`. `AncillaryVFFilter` reads that flag. Home NSFW rules emit Interstitial; Recs has Drop twins (`NSFW_HIGH_PRECISION_DROP`, etc.). Interstitial means keep-and-warn, not hard-drop. Not rewritten.

This is not #115 (Following quotes at Home), #117 (QuoteHydrator TES), #118 (quoted id on RTs), #119 (RT primary looked up by wrapper id), or #121 (VF `Err` / missing key). #121 leftover text called this Interstitial≠Drop path out and said TES-flag miss is separate.

## Bug

TES tweet-flag RPCs (`nsfw_user`, `nsfw_admin`, `takedown_reasons`, `nullcast`, `media`) already distinguish Found / NotFound / Failed. `build_tweet_features` then does `get(...).unwrap_or(false)` and `get_or_default`.

Failed and NotFound both become “flag unset”. NSFW interstitial / Recs Drop, legal takedown, nullcast, and DMCA/geo rules never see the label.

- Entry: `TesHydrator::hydrate_tweets` → `TweetHydration`
- Sink: `NsfwAuthorInterstitialRule`, tweet NSFW Recs drops, legal takedown, `NullcastedTweetDropRule`, Recs DMCA/geo
- Break: Failed TES flag read assembled as false
- Viewer effect: NSFW or taken-down post (or a quote/reply of one) serves as a normal card
- Twin: #121 fail-closes a missing VF map key. TES flags were the leftover that issue called out.

Genuine `NotFound` / `Ok(None)` (no flag) is unchanged.

## Fix

If any of those five lookups is Failed for a tweet id, drop that candidate from the hydrated set. `FilterTweets` already maps a missing hydrated candidate to `Verdict::unresolved_author` (Drop / `UnspecifiedReason`). Mixer `VFFilter` and `should_drop_ancillary` already drop that reason.

Do not treat Interstitial as Drop.

## Tests

- Found false / NotFound / empty batch → not a safety failure
- Failed nsfw_user, takedown_reasons, nullcast, or media → safety failure
- `retain_candidates_with_usable_tes_flags` drops only the Failed id
- `Hydrated::is_failed` is true only for Failed

Standalone decision-table harness (same Found / NotFound / Failed arms): 12 assertions passed.

`cargo test` cannot run. Public dump has no visibility-filtering / Home Mixer manifest.

## Leftover

Gizmoduck author NSFW miss is #125. Socialgraph relationship miss still fail-opens as “not muted / not blocked”.