### PR TITLE
Stop InNetwork from skipping cache hits and leaving a stale VF stamp

### DIFF
--- a/home-mixer/candidate_hydrators/in_network_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/in_network_candidate_hydrator.rs
@@ -8,8 +8,11 @@ pub struct InNetworkCandidateHydrator;
 
 #[async_trait]
 impl Hydrator<ScoredPostsQuery, PostCandidate> for InNetworkCandidateHydrator {
-    fn enable(&self, query: &ScoredPostsQuery) -> bool {
-        !query.has_cached_posts
+    // Always on. FollowedUserIdsQueryHydrator is request-fresh and this is a
+    // local HashSet lookup. Skipping cache hits leaves Redis in_network (TTL
+    // 180s) in place; VF then buckets TimelineHome vs Recs from that stamp.
+    fn enable(&self, _query: &ScoredPostsQuery) -> bool {
+        true
     }
 
     async fn hydrate(
@@ -41,5 +44,80 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for InNetworkCandidateHydrator {
 
     fn update(&self, candidate: &mut PostCandidate, hydrated: PostCandidate) {
         candidate.in_network = hydrated.in_network;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::user_features::UserFeatures;
+
+    fn query(viewer_id: u64, followed: Vec<i64>, has_cached_posts: bool) -> ScoredPostsQuery {
+        ScoredPostsQuery {
+            user_id: viewer_id,
+            user_features: UserFeatures {
+                followed_user_ids: followed,
+                ..Default::default()
+            },
+            has_cached_posts,
+            ..Default::default()
+        }
+    }
+
+    async fn stamp(
+        query: &ScoredPostsQuery,
+        author_id: u64,
+        cached_in_network: Option<bool>,
+    ) -> Option<bool> {
+        let hydrator = InNetworkCandidateHydrator;
+        let candidates = vec![PostCandidate {
+            tweet_id: 1,
+            author_id,
+            in_network: cached_in_network,
+            ..Default::default()
+        }];
+        let hydrated = hydrator.hydrate(query, &candidates).await;
+        let mut candidate = candidates.into_iter().next().unwrap();
+        hydrator.update(&mut candidate, hydrated.into_iter().next().unwrap().unwrap());
+        candidate.in_network
+    }
+
+    #[test]
+    fn enable_stays_on_for_cached_posts() {
+        let hydrator = InNetworkCandidateHydrator;
+        assert!(hydrator.enable(&query(1, vec![42], true)));
+        assert!(hydrator.enable(&query(1, vec![42], false)));
+    }
+
+    #[tokio::test]
+    async fn restamps_stale_cached_in_network_after_unfollow() {
+        let query = query(1, vec![], true);
+        assert_eq!(
+            stamp(&query, 42, Some(true)).await,
+            Some(false),
+            "cached Home stamp after unfollow must become OON"
+        );
+    }
+
+    #[tokio::test]
+    async fn restamps_stale_cached_oon_after_follow() {
+        let query = query(1, vec![42], true);
+        assert_eq!(
+            stamp(&query, 42, Some(false)).await,
+            Some(true),
+            "cached Recs stamp after follow must become Home"
+        );
+    }
+
+    #[tokio::test]
+    async fn followed_author_is_in_network() {
+        let query = query(1, vec![42], false);
+        assert_eq!(stamp(&query, 42, None).await, Some(true));
+    }
+
+    #[tokio::test]
+    async fn unfollowed_author_is_oon() {
+        let query = query(1, vec![42], false);
+        assert_eq!(stamp(&query, 99, None).await, Some(false));
     }
 }


### PR DESCRIPTION
## Bug

#128–#132 leftover. `InNetworkCandidateHydrator.enable` was `!has_cached_posts`. #131 called that out and left it.

`FollowedUserIdsQueryHydrator` still runs on a cache hit. InNetwork is a local HashSet lookup. Redis keeps the old `in_network` for 180s. `VFCandidateHydrator` still runs and buckets `TimelineHome` vs `TimelineHomeRecommendations` from that stamp.

- Unfollow a DoNotAmplify / NSFW HP author: cache still says Home. Recs Drop does not fire.
- Follow someone: cache still says OON. Recs Drop fires on a followee.
- Cache miss that stamped OON on `author_id = 0` (#128), then TES filled the author: the Redis row keeps `in_network = false`. Cache hit never restamps.

CoreData stays skipped. TES is an RPC. Tweet `author_id` does not change. #132 already covers NightOwl `already_hydrated`. Gizmoduck stays skipped. VF still applies NSFW on the restamped safety level.

Not #128 (order). Not #131 (TES overwrite). Not #132 (`already_hydrated`).

## Fix

One file, `home-mixer/candidate_hydrators/in_network_candidate_hydrator.rs`.

`enable` is always true.

## Tests

- `enable` is true on `has_cached_posts`
- Cached Home stamp after unfollow becomes OON
- Cached Recs stamp after follow becomes Home
- Followed / unfollowed miss path unchanged

`cargo test` cannot run. Public dump has no Home Mixer manifest. Same control flow compiled and run as a rustc model: 6/6 passed (old gate keeps the stale stamp; new gate restamps).