### PR TITLE
Fail closed when socialgraph mute/block relationship reads fail

### DIFF
--- a/home-mixer/candidate_hydrators/blocked_by_hydrator.rs
+++ b/home-mixer/candidate_hydrators/blocked_by_hydrator.rs
@@ -34,9 +34,19 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for BlockedByHydrator {
             .await
         {
             Ok(ids) => ids,
-            Err(e) => {
-                let err_msg = e.to_string();
-                return candidates.iter().map(|_| Err(err_msg.clone())).collect();
+            Err(_) => {
+                // Err is skipped by update_all, leaving author_blocks_viewer
+                // None. AuthorSocialgraphFilter then unwrap_or(false).
+                // Write Some(true) so the filter drops.
+                return candidates
+                    .iter()
+                    .map(|_| {
+                        Ok(PostCandidate {
+                            author_blocks_viewer: Some(true),
+                            ..Default::default()
+                        })
+                    })
+                    .collect();
             }
         };
         candidates

--- a/home-mixer/candidate_hydrators/following_blocked_by_hydrator.rs
+++ b/home-mixer/candidate_hydrators/following_blocked_by_hydrator.rs
@@ -33,9 +33,19 @@ impl Hydrator<ScoredPostsQuery, PostCandidate> for FollowingBlockedByHydrator {
             .await
         {
             Ok(ids) => ids,
-            Err(e) => {
-                let err_msg = e.to_string();
-                return candidates.iter().map(|_| Err(err_msg.clone())).collect();
+            Err(_) => {
+                // Same as BlockedByHydrator: Err is skipped by update_all,
+                // and the filter treats None as not-blocked. Stamp true.
+                return candidates
+                    .iter()
+                    .map(|candidate| {
+                        Ok(PostCandidate {
+                            author_blocks_viewer: Some(true),
+                            quoted_author_blocks_viewer: candidate.quoted_user_id.map(|_| true),
+                            ..Default::default()
+                        })
+                    })
+                    .collect();
             }
         };
         candidates

--- a/visibility-filtering/hydration/mod.rs
+++ b/visibility-filtering/hydration/mod.rs
@@ -17,7 +17,7 @@ use crate::models::{
 };
 use crate::rules::SafetyLevel;
 use crate::safety_label_source::SafetyLabelSource;
-use batch::TweetHydrationBatch;
+use batch::{Hydrated, TweetHydrationBatch};
 use exclusive_content_hydrator::ExclusiveContentHydrator;
 use fallback_cache::FallbackCache;
 use gizmoduck_hydrator::GizmoduckAuthorHydrator;
@@ -60,6 +60,26 @@ struct CandidateFeatures {
     safety_labels: HashMap<TweetId, SafetyLabelMap>,
     relationships: TweetHydrationBatch<ViewerAuthorRelationship>,
     exclusive_content: HashMap<TweetId, Option<ExclusiveContentFeatures>>,
+}
+
+/// Drop candidates whose socialgraph relationship read Failed.
+/// `assemble` uses `get_or_default`, which turns Failed into "not muted /
+/// not blocked". FilterTweets already maps a missing hydrated candidate to
+/// `Verdict::unresolved_author` (Drop). Genuine Found (including all-false)
+/// is kept. Logged-out viewers are Found(default), not Failed.
+pub(crate) fn retain_candidates_with_usable_relationships(
+    candidates: Vec<TweetCandidateInput>,
+    relationships: &TweetHydrationBatch<ViewerAuthorRelationship>,
+) -> Vec<TweetCandidateInput> {
+    candidates
+        .into_iter()
+        .filter(|c| {
+            !matches!(
+                relationships.hydrated(&c.tweet_id),
+                Some(Hydrated::Failed(_))
+            )
+        })
+        .collect()
 }
 
 impl CandidateFeatures {
@@ -207,6 +227,8 @@ impl HydrationPipeline {
                 label_response,
             } = safety_labels;
 
+            let candidates =
+                retain_candidates_with_usable_relationships(candidates, &relationships);
             let tweet_features = self.tes_hydrator.assemble_tweet_features(
                 &candidates,
                 &core_datas,
@@ -330,5 +352,95 @@ mod tests {
             .map(|(author, count)| (author.get(), count))
             .collect();
         assert_eq!(counts, HashMap::from([(10, 2), (20, 1)]));
+    }
+
+    fn tweet(tweet_id: u64, author_id: u64) -> TweetCandidateInput {
+        resolve_candidate(&raw(tweet_id, Some(author_id)), &HashMap::new()).unwrap()
+    }
+
+    #[test]
+    fn retain_drops_failed_relationship_and_keeps_found() {
+        let relationships = TweetHydrationBatch::from_results(
+            [TweetId(1), TweetId(2)],
+            HashMap::from([
+                (
+                    TweetId(1),
+                    Err::<Option<ViewerAuthorRelationship>, _>("socialgraph unavailable"),
+                ),
+                (TweetId(2), Ok(Some(ViewerAuthorRelationship::default()))),
+            ]),
+        );
+
+        let kept = retain_candidates_with_usable_relationships(
+            vec![tweet(1, 10), tweet(2, 20)],
+            &relationships,
+        );
+
+        assert_eq!(
+            kept.iter().map(|c| c.tweet_id.0).collect::<Vec<_>>(),
+            vec![2]
+        );
+    }
+
+    #[test]
+    fn retain_keeps_found_mute_and_block() {
+        let relationships = TweetHydrationBatch::from_results(
+            [TweetId(1)],
+            HashMap::from([(
+                TweetId(1),
+                Ok::<_, anyhow::Error>(Some(ViewerAuthorRelationship {
+                    viewer_mutes_author: true,
+                    viewer_blocks_author: true,
+                    ..Default::default()
+                })),
+            )]),
+        );
+
+        let kept = retain_candidates_with_usable_relationships(vec![tweet(1, 10)], &relationships);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].tweet_id.0, 1);
+    }
+
+    #[test]
+    fn retain_drops_missing_relationship_key() {
+        let relationships = TweetHydrationBatch::from_values(
+            [TweetId(1)],
+            HashMap::from([(TweetId(1), ViewerAuthorRelationship::default())]),
+        );
+
+        let kept = retain_candidates_with_usable_relationships(
+            vec![tweet(1, 10), tweet(2, 20)],
+            &relationships,
+        );
+
+        assert_eq!(
+            kept.iter().map(|c| c.tweet_id.0).collect::<Vec<_>>(),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn assemble_still_defaults_failed_relationship_if_not_retained() {
+        let resolved = tweet(1, 10);
+        let results = CandidateFeatures {
+            tweet_features: HashMap::new(),
+            author_features: TweetHydrationBatch::empty(),
+            safety_labels: HashMap::new(),
+            relationships: TweetHydrationBatch::from_results(
+                [TweetId(1)],
+                HashMap::from([(
+                    TweetId(1),
+                    Err::<Option<ViewerAuthorRelationship>, _>("socialgraph unavailable"),
+                )]),
+            ),
+            exclusive_content: HashMap::new(),
+        };
+
+        let assembled = results.assemble(&[resolved]);
+
+        assert_eq!(assembled.len(), 1);
+        assert!(!assembled[0].relationship.viewer_mutes_author);
+        assert!(!assembled[0].relationship.viewer_blocks_author);
     }
 }


### PR DESCRIPTION
## Wave 3 check

#134 leftover: socialgraph relationship miss still fail-opens as not muted / not blocked. Verified on `xai-org/main` (`902a06f`).

This is not #134 (TES NSFW / takedown / nullcast / media flags). This is not #121 (mixer VF `Err` / missing key). Those stay on their own PRs.

## Bug

`SocialgraphHydrator` already marks an empty or failed Flock read as `Hydrated::Failed`. `assemble` then does `relationships.get_or_default`, so Failed becomes all-false. `ViewerMutesAuthorRule` / `ViewerBlocksAuthorRule` / `MutedRetweetsRule` never fire.

Latest Following never loads mixer mute/block lists (`reverse_chron_posts_pipeline` query hydrators are empty). For You list hydrators return `Err` on RPC failure; `hydrate_query` ignores that and leaves empty lists. In both cases VF is the mute/block sink. The sink was assembling Failed as not-muted / not-blocked.

Mixer `BlockedByHydrator` / `FollowingBlockedByHydrator` returned `Err` on `check_blocked_by` failure. `update_all` skips `Err`, so `author_blocks_viewer` stays `None`. `AuthorSocialgraphFilter` does `unwrap_or(false)`. VF does not check author-blocks-viewer.

- Entry: `SocialgraphHydrator::hydrate` → `CandidateFeatures::assemble`; mixer `BlockedByHydrator` / `FollowingBlockedByHydrator`
- Sink: VF mute/block/mute-retweet rules; mixer `AuthorSocialgraphFilter`
- Break: Failed relationship assembled as false; mixer graph `Err` written as not-blocked
- Viewer effect: a muted or blocked author (or an author who blocked the viewer) still serves when the graph RPC fails
- Twin: #134 drops a candidate whose TES safety-flag read Failed. Same retain → `unresolved_author` path.

Genuine `Found` (including all-false, nobody muted/blocked) is unchanged. Logged-out viewers are `Found(default)`, not Failed.

## Fix

If the relationship lookup is Failed for a tweet id, drop that candidate from the hydrated set. `FilterTweets` already maps a missing hydrated candidate to `Verdict::unresolved_author`.

On mixer `check_blocked_by` `Err`, write `author_blocks_viewer: Some(true)` (and quoted `Some(true)` when a quoted author is present) so `update_all` applies it and the filter drops.

## Tests

- Failed relationship dropped; Found default kept
- Found mute/block still assembled (rules drop)
- Missing relationship key dropped
- Assemble-without-retain still defaults Failed to false (documents the hole)

Standalone decision-table harness (same retain / BlockedBy / filter arms): 15 assertions passed.

`cargo test` cannot run. Public dump has no visibility-filtering / Home Mixer manifest.

## Leftover

`QuoteHydrator::get_blocked_by` still `unwrap_or_default()` (#117). Partial Flock result slots still default missing mute/block graphs to empty. Mixer mute/block *list* miss on For You still leaves empty lists; Latest Following never loads those lists. VF Failed is the sink for viewer mute/block after this change.

Fork pointer (do not merge): https://github.com/Pitchfork-and-Torch/x-algorithm/pull/27