### PR TITLE
Drop quotes whose quoted author handle matches a muted keyword

### DIFF
--- a/home-mixer/candidate_hydrators/gizmoduck_hydrator.rs
+++ b/home-mixer/candidate_hydrators/gizmoduck_hydrator.rs
@@ -39,6 +39,7 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
         GizmoduckCacheKey {
             author_id: candidate.author_id,
             retweeted_user_id: candidate.retweeted_user_id,
+            quoted_user_id: candidate.quoted_user_id,
         }
     }
 
@@ -47,6 +48,7 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
             author_followers_count: hydrated.author_followers_count,
             author_screen_name: hydrated.author_screen_name.clone(),
             retweeted_screen_name: hydrated.retweeted_screen_name.clone(),
+            quoted_screen_name: hydrated.quoted_screen_name.clone(),
             nsfw_author: hydrated.nsfw_author,
             nsfw_author_ads: hydrated.nsfw_author_ads,
             nsfw_author_phoenix: hydrated.nsfw_author_phoenix,
@@ -58,6 +60,7 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
             author_followers_count: value.author_followers_count,
             author_screen_name: value.author_screen_name,
             retweeted_screen_name: value.retweeted_screen_name,
+            quoted_screen_name: value.quoted_screen_name,
             nsfw_author: value.nsfw_author,
             nsfw_author_ads: value.nsfw_author_ads,
             nsfw_author_phoenix: value.nsfw_author_phoenix,
@@ -79,6 +82,12 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
                 candidates
                     .iter()
                     .filter_map(|c| c.retweeted_user_id)
+                    .map(|id| id as i64),
+            )
+            .chain(
+                candidates
+                    .iter()
+                    .filter_map(|c| c.quoted_user_id)
                     .map(|id| id as i64),
             )
             .collect::<HashSet<i64>>()
@@ -106,8 +115,17 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
                 Some(Err(err)) => Err(err.to_string()),
             };
 
-            let hydrated = match (user, retweet_user) {
-                (Ok(user), Ok(retweet_user)) => {
+            let quoted_user = candidate
+                .quoted_user_id
+                .and_then(|quoted_user_id| users.get(&(quoted_user_id as i64)));
+            let quoted_user = match quoted_user {
+                Some(Ok(Some(user))) => Ok(Some(user)),
+                Some(Ok(None)) | None => Ok(None),
+                Some(Err(err)) => Err(err.to_string()),
+            };
+
+            let hydrated = match (user, retweet_user, quoted_user) {
+                (Ok(user), Ok(retweet_user), Ok(quoted_user)) => {
                     let user_counts = user.and_then(|user| user.user.as_ref().map(|u| &u.counts));
                     let user_profile = user.and_then(|user| user.user.as_ref().map(|u| &u.profile));
 
@@ -120,6 +138,11 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
                         retweet_user.and_then(|user| user.user.as_ref().map(|u| &u.profile));
                     let retweeted_screen_name: Option<String> =
                         retweet_profile.map(|x| x.screen_name.clone());
+
+                    let quoted_profile =
+                        quoted_user.and_then(|user| user.user.as_ref().map(|u| &u.profile));
+                    let quoted_screen_name: Option<String> =
+                        quoted_profile.map(|x| x.screen_name.clone());
 
                     let author = user.and_then(|u| u.user.as_ref());
                     let nsfw_author: Option<bool> = author.map(|u| {
@@ -152,13 +175,14 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
                         author_followers_count,
                         author_screen_name,
                         retweeted_screen_name,
+                        quoted_screen_name,
                         nsfw_author,
                         nsfw_author_ads,
                         nsfw_author_phoenix,
                         ..Default::default()
                     })
                 }
-                (Err(err), _) | (_, Err(err)) => Err(err),
+                (Err(err), _, _) | (_, Err(err), _) | (_, _, Err(err)) => Err(err),
             };
             hydrated_candidates.push(hydrated);
         }
@@ -170,6 +194,7 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
         candidate.author_followers_count = hydrated.author_followers_count;
         candidate.author_screen_name = hydrated.author_screen_name;
         candidate.retweeted_screen_name = hydrated.retweeted_screen_name;
+        candidate.quoted_screen_name = hydrated.quoted_screen_name;
         candidate.nsfw_author = hydrated.nsfw_author;
         candidate.nsfw_author_ads = hydrated.nsfw_author_ads;
         candidate.nsfw_author_phoenix = hydrated.nsfw_author_phoenix;
@@ -180,6 +205,7 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for GizmoduckCandidateHydra
 pub struct GizmoduckCacheKey {
     pub author_id: u64,
     pub retweeted_user_id: Option<u64>,
+    pub quoted_user_id: Option<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -187,6 +213,7 @@ pub struct GizmoduckCacheValue {
     pub author_followers_count: Option<i32>,
     pub author_screen_name: Option<String>,
     pub retweeted_screen_name: Option<String>,
+    pub quoted_screen_name: Option<String>,
     pub nsfw_author: Option<bool>,
     pub nsfw_author_ads: Option<bool>,
     pub nsfw_author_phoenix: Option<bool>,

--- a/home-mixer/candidate_hydrators/mod.rs
+++ b/home-mixer/candidate_hydrators/mod.rs
@@ -14,6 +14,7 @@ pub mod language_code_hydrator;
 pub mod media_info_hydrator;
 pub mod mutual_follow_jaccard_hydrator;
 pub mod quote_hydrator;
+pub mod quoted_author_screen_name_hydrator;
 pub mod quoted_post_text_hydrator;
 pub mod semantic_id_hydrator;
 pub mod subscription_hydrator;

--- a/home-mixer/candidate_hydrators/quoted_author_screen_name_hydrator.rs
+++ b/home-mixer/candidate_hydrators/quoted_author_screen_name_hydrator.rs
@@ -1,0 +1,67 @@
+use crate::clients::gizmoduck_client::GizmoduckClient;
+use crate::models::candidate::PostCandidate;
+use crate::models::query::ScoredPostsQuery;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tonic::async_trait;
+use xai_candidate_pipeline::hydrator::Hydrator;
+
+pub struct QuotedAuthorScreenNameHydrator {
+    pub gizmoduck_client: Arc<dyn GizmoduckClient + Send + Sync>,
+}
+
+impl QuotedAuthorScreenNameHydrator {
+    pub fn new(gizmoduck_client: Arc<dyn GizmoduckClient + Send + Sync>) -> Self {
+        Self { gizmoduck_client }
+    }
+}
+
+#[async_trait]
+impl Hydrator<ScoredPostsQuery, PostCandidate> for QuotedAuthorScreenNameHydrator {
+    async fn hydrate(
+        &self,
+        _query: &ScoredPostsQuery,
+        candidates: &[PostCandidate],
+    ) -> Vec<Result<PostCandidate, String>> {
+        let quoted_user_ids: Vec<i64> = candidates
+            .iter()
+            .filter_map(|c| c.quoted_user_id)
+            .map(|id| id as i64)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let users = if quoted_user_ids.is_empty() {
+            Default::default()
+        } else {
+            self.gizmoduck_client.get_users(quoted_user_ids).await
+        };
+
+        candidates
+            .iter()
+            .map(|candidate| {
+                let quoted_user = candidate
+                    .quoted_user_id
+                    .and_then(|id| users.get(&(id as i64)));
+                match quoted_user {
+                    Some(Err(err)) => Err(err.to_string()),
+                    Some(Ok(Some(user))) => Ok(PostCandidate {
+                        quoted_screen_name: user
+                            .user
+                            .as_ref()
+                            .map(|u| u.profile.screen_name.clone()),
+                        ..Default::default()
+                    }),
+                    Some(Ok(None)) | None => Ok(PostCandidate {
+                        quoted_screen_name: None,
+                        ..Default::default()
+                    }),
+                }
+            })
+            .collect()
+    }
+
+    fn update(&self, candidate: &mut PostCandidate, hydrated: PostCandidate) {
+        candidate.quoted_screen_name = hydrated.quoted_screen_name;
+    }
+}

--- a/home-mixer/candidate_pipeline/reverse_chron_posts_pipeline.rs
+++ b/home-mixer/candidate_pipeline/reverse_chron_posts_pipeline.rs
@@ -2,9 +2,11 @@ use crate::candidate_hydrators::ads_brand_safety_vf_hydrator::AdsBrandSafetyVfHy
 use crate::candidate_hydrators::conversation_gap_ancestor_hydrator::ConversationGapAncestorHydrator;
 use crate::candidate_hydrators::core_data_candidate_hydrator::CoreDataCandidateHydrator;
 use crate::candidate_hydrators::following_blocked_by_hydrator::FollowingBlockedByHydrator;
+use crate::candidate_hydrators::quoted_author_screen_name_hydrator::QuotedAuthorScreenNameHydrator;
 use crate::candidate_hydrators::quoted_post_text_hydrator::QuotedPostTextHydrator;
 use crate::candidate_hydrators::tweet_type_metrics_hydrator::TweetTypeMetricsHydrator;
 use crate::candidate_hydrators::vf_following_candidate_hydrator::VFFollowingCandidateHydrator;
+use crate::clients::gizmoduck_client::{GizmoduckClient, MockGizmoduckClient, ProdGizmoduckClient};
 use crate::clients::night_owl_client::{MockNightOwlClient, NightOwlClient, ProdNightOwlClient};
 use crate::clients::s2s::{S2S_CHAIN_PATH, S2S_CRT_PATH, S2S_KEY_PATH};
 use crate::clients::tweet_entity_service_client::{MockTESClient, ProdTESClient, TESClient};
@@ -56,6 +58,7 @@ impl ReverseChronPostsPipeline {
             xai_vf_client,
             vf_safety_labels_client,
             socialgraph_client,
+            gizmoduck_client,
         ) = tokio::join!(
             async {
                 Arc::new(
@@ -112,6 +115,17 @@ impl ReverseChronPostsPipeline {
                     .expect("Failed to create flock SocialGraphClient"),
                 ) as Arc<dyn SocialGraphClientOps>
             },
+            async {
+                Arc::new(
+                    ProdGizmoduckClient::new(
+                        None,
+                        datacenter,
+                        Some("home-mixer.prod".to_string()),
+                    )
+                    .await
+                    .expect("Failed to create Gizmoduck client"),
+                ) as Arc<dyn GizmoduckClient + Send + Sync>
+            },
         );
 
         Self::build(
@@ -121,6 +135,7 @@ impl ReverseChronPostsPipeline {
             xai_vf_client,
             vf_safety_labels_client,
             socialgraph_client,
+            gizmoduck_client,
         )
         .await
     }
@@ -133,6 +148,7 @@ impl ReverseChronPostsPipeline {
             Arc::new(MockVfClient) as Arc<dyn VfClient + Send + Sync>,
             Arc::new(MockTweetSafetyLabelClient) as Arc<dyn TweetSafetyLabelClient>,
             Arc::new(MockSocialGraphClient) as Arc<dyn SocialGraphClientOps>,
+            Arc::new(MockGizmoduckClient::default()) as Arc<dyn GizmoduckClient + Send + Sync>,
         )
         .await
     }
@@ -144,6 +160,7 @@ impl ReverseChronPostsPipeline {
         xai_vf_client: Arc<dyn VfClient + Send + Sync>,
         vf_safety_labels_client: Arc<dyn TweetSafetyLabelClient>,
         socialgraph_client: Arc<dyn SocialGraphClientOps>,
+        gizmoduck_client: Arc<dyn GizmoduckClient + Send + Sync>,
     ) -> Self {
         let sources: Vec<Box<dyn Source<ScoredPostsQuery, PostCandidate>>> =
             vec![Box::new(FollowingNightOwlSource {
@@ -156,6 +173,7 @@ impl ReverseChronPostsPipeline {
                 &tes_client,
             ))),
             Box::new(QuotedPostTextHydrator::new(tes_client)),
+            Box::new(QuotedAuthorScreenNameHydrator::new(gizmoduck_client)),
         ];
 
         let filters: Vec<Box<dyn Filter<ScoredPostsQuery, PostCandidate>>> = vec![

--- a/home-mixer/filters/following_viewer_muted_keyword_filter.rs
+++ b/home-mixer/filters/following_viewer_muted_keyword_filter.rs
@@ -59,7 +59,94 @@ fn candidate_matches(
 ) -> bool {
     std::iter::once(candidate.tweet_text.as_str())
         .chain(candidate.quoted_tweet_text.as_deref())
+        .chain(candidate.quoted_screen_name.as_deref())
         .chain(candidate.ancestor_texts.values().map(String::as_str))
         .filter(|text| !text.is_empty())
         .any(|text| matcher.matches(&tokenizer.tokenize(text)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::user_features::UserFeatures;
+
+    fn query(muted_keywords: Vec<String>) -> ScoredPostsQuery {
+        ScoredPostsQuery {
+            user_features: UserFeatures {
+                muted_keywords,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn text_candidate(tweet_id: u64, tweet_text: &str) -> PostCandidate {
+        PostCandidate {
+            tweet_id,
+            tweet_text: tweet_text.to_string(),
+            author_id: 12345,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drops_quote_when_quoted_author_handle_matches_muted_keyword() {
+        let filter = FollowingViewerMutedKeywordFilter::new();
+        let quote = PostCandidate {
+            tweet_id: 1,
+            tweet_text: "sharing this".to_string(),
+            quoted_tweet_text: Some("ordinary news".to_string()),
+            quoted_user_id: Some(99),
+            quoted_screen_name: Some("spamaccount".to_string()),
+            author_id: 12345,
+            ..Default::default()
+        };
+
+        let result = filter.filter(
+            &query(vec!["spamaccount".to_string()]),
+            vec![quote, text_candidate(2, "sharing this")],
+        );
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 2);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn keeps_quote_when_quoted_author_handle_does_not_match() {
+        let filter = FollowingViewerMutedKeywordFilter::new();
+        let quote = PostCandidate {
+            tweet_id: 1,
+            tweet_text: "sharing this".to_string(),
+            quoted_tweet_text: Some("ordinary news".to_string()),
+            quoted_user_id: Some(99),
+            quoted_screen_name: Some("normaluser".to_string()),
+            author_id: 12345,
+            ..Default::default()
+        };
+
+        let result = filter.filter(&query(vec!["spamaccount".to_string()]), vec![quote]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert!(result.removed.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn still_drops_when_quoted_text_matches() {
+        let filter = FollowingViewerMutedKeywordFilter::new();
+        let quote = PostCandidate {
+            tweet_id: 1,
+            tweet_text: "sharing this".to_string(),
+            quoted_tweet_text: Some("this is spam content".to_string()),
+            quoted_screen_name: Some("normaluser".to_string()),
+            author_id: 12345,
+            ..Default::default()
+        };
+
+        let result = filter.filter(&query(vec!["spam".to_string()]), vec![quote]);
+
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 1);
+    }
 }

--- a/home-mixer/filters/viewer_muted_keyword_filter.rs
+++ b/home-mixer/filters/viewer_muted_keyword_filter.rs
@@ -43,8 +43,7 @@ impl Filter<ScoredPostsQuery, PostCandidate> for ViewerMutedKeywordFilter {
             let mut removed = Vec::new();
 
             for candidate in candidates {
-                let tweet_text_token_sequence = tokenizer.tokenize(&candidate.tweet_text);
-                if matcher.matches(&tweet_text_token_sequence) {
+                if candidate_matches(&candidate, &tokenizer, &matcher) {
                     removed.push(candidate);
                 } else {
                     kept.push(candidate);
@@ -54,6 +53,17 @@ impl Filter<ScoredPostsQuery, PostCandidate> for ViewerMutedKeywordFilter {
             FilterResult { kept, removed }
         })
     }
+}
+
+fn candidate_matches(
+    candidate: &PostCandidate,
+    tokenizer: &TweetTokenizer,
+    matcher: &MatchTweetGroup,
+) -> bool {
+    std::iter::once(candidate.tweet_text.as_str())
+        .chain(candidate.quoted_screen_name.as_deref())
+        .filter(|text| !text.is_empty())
+        .any(|text| matcher.matches(&tokenizer.tokenize(text)))
 }
 
 #[cfg(test)]
@@ -314,5 +324,48 @@ mod tests {
         assert_eq!(result.kept.len(), 1);
         assert_eq!(result.kept[0].tweet_id, 4);
         assert_eq!(result.removed.len(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drops_quote_when_quoted_author_handle_matches_muted_keyword() {
+        let filter = ViewerMutedKeywordFilter::new();
+        let query = create_test_query(vec!["spamaccount".to_string()]);
+
+        let quote = PostCandidate {
+            tweet_id: 1,
+            tweet_text: "sharing this".to_string(),
+            quoted_tweet_text: Some("ordinary news".to_string()),
+            quoted_user_id: Some(99),
+            quoted_screen_name: Some("spamaccount".to_string()),
+            author_id: 12345,
+            ..Default::default()
+        };
+
+        let result = filter.filter(&query, vec![quote, create_test_candidate(2, "sharing this")]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 2);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn keeps_quote_when_only_quoted_text_would_match_keyword() {
+        let filter = ViewerMutedKeywordFilter::new();
+        let query = create_test_query(vec!["spam".to_string()]);
+
+        let quote = PostCandidate {
+            tweet_id: 1,
+            tweet_text: "sharing this".to_string(),
+            quoted_tweet_text: Some("this is spam content".to_string()),
+            quoted_screen_name: Some("normaluser".to_string()),
+            author_id: 12345,
+            ..Default::default()
+        };
+
+        let result = filter.filter(&query, vec![quote]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert!(result.removed.is_empty());
     }
 }

--- a/home-mixer/models/candidate.rs
+++ b/home-mixer/models/candidate.rs
@@ -44,6 +44,8 @@ pub struct PostCandidate {
     pub author_followers_count: Option<i32>,
     pub author_screen_name: Option<String>,
     pub retweeted_screen_name: Option<String>,
+    #[serde(default)]
+    pub quoted_screen_name: Option<String>,
     pub visibility_reason: Option<vf::FilteredReason>,
     pub drop_ancillary_posts: Option<bool>,
     pub subscription_author_id: Option<u64>,
@@ -183,6 +185,11 @@ impl CandidateHelpers for PostCandidate {
             (self.retweeted_screen_name.clone(), self.retweeted_user_id)
         {
             screen_names.insert(retweeted_user_id, retweeted_screen_name);
+        }
+        if let (Some(quoted_screen_name), Some(quoted_user_id)) =
+            (self.quoted_screen_name.clone(), self.quoted_user_id)
+        {
+            screen_names.insert(quoted_user_id, quoted_screen_name);
         }
         screen_names
     }


### PR DESCRIPTION
## Bug

FollowingViewerMutedKeywordFilter already drops when quoted tweet text matches a muted keyword. AuthorSocialgraphFilter already drops when the viewer mutes the quoted author by user id (PR 23). Mute-keyword matching never looked at the quoted author handle.

Gizmoduck already filled author_screen_name and retweeted_screen_name. get_screen_names() omitted quoted_user_id. Latest Following never fetched the quoted handle at all.

A followee quoting @spamaccount with comment "look" and quoted text "hello" still served when the viewer muted the keyword spamaccount. Mention-in-text already drops (test_mention_keyword). Quoted text already drops on Following. This is the leftover author-of-quoted edge.

This is not PR 96 (quote/reply/retweet TEXT). Not PR 23 (mute quoted author by id). Not PR 100 (blocked-by retweeted author). Not PR 108 (Following author blocked-by).

## Fix

Hydrate quoted_screen_name from Gizmoduck (Phoenix already had the client; Latest Following gets a quoted-user-only hydrator). Match that handle in FollowingViewerMutedKeywordFilter and ViewerMutedKeywordFilter.

## Proof

- Entry: Night Owl / QuoteHydrator quoted_user_id; Gizmoduck profile.screen_name
- Sink: FollowingViewerMutedKeywordFilter / ViewerMutedKeywordFilter
- Break: mute-keyword matched tweet_text and quoted_tweet_text; quoted author handle was never hydrated or matched
- Viewer effect: quote of @mutedkeyword still serves on Latest Following and For You
- Twin: test_mention_keyword drops @handle in tweet_text; Following already drops matching quoted_tweet_text

## Tests

- drops_quote_when_quoted_author_handle_matches_muted_keyword (Following and For You)
- keeps_quote_when_quoted_author_handle_does_not_match
- keeps_quote_when_only_quoted_text_would_match_keyword (For You does not clone PR 96 text matching)
- still_drops_when_quoted_text_matches (Following twin unchanged)
- unit tests added; cargo test cannot run in the public dump