### PR TITLE
Stop RankingScorer from ranking posts with no Phoenix heads

### DIFF
--- a/home-mixer/scorers/phoenix_scorer.rs
+++ b/home-mixer/scorers/phoenix_scorer.rs
@@ -21,6 +21,18 @@ pub struct PhoenixScorer {
 }
 
 impl PhoenixScorer {
+    fn refuse_without_sequence(
+        query: &ScoredPostsQuery,
+        n: usize,
+    ) -> Option<Vec<Result<PostCandidate, String>>> {
+        query.scoring_sequence.is_none().then(|| {
+            vec![
+                Err("Phoenix scoring_sequence missing; refusing empty scores".to_string());
+                n
+            ]
+        })
+    }
+
     fn resolve_cluster(query: &ScoredPostsQuery) -> PhoenixCluster {
         let configured_cluster =
             PhoenixCluster::parse(&query.params.get(PhoenixInferenceClusterId));
@@ -85,9 +97,12 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for PhoenixScorer {
             ProductSurface::HomeTimelineRanking
         };
 
-        if query.scoring_sequence.is_none() {
-            return vec![Ok(PostCandidate::default()); candidates.len()];
-        };
+        // Fail closed: stamping Default phoenix_scores (all None) plus
+        // last_scored_at_ms lets RankingScorer invent NEGATIVE_SCORES_OFFSET
+        // and TopK keep the post. update_all skips Err.
+        if let Some(refused) = Self::refuse_without_sequence(query, candidates.len()) {
+            return refused;
+        }
 
         let cluster = Self::resolve_cluster(query);
         let request = build_prediction_request(query, candidates, product_surface);
@@ -127,5 +142,34 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for PhoenixScorer {
         candidate.prediction_request_id = scored.prediction_request_id;
         candidate.last_scored_at_ms = scored.last_scored_at_ms;
         candidate.reranker_head_tag = scored.reranker_head_tag;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::query::ScoredPostsQuery;
+
+    #[test]
+    fn missing_scoring_sequence_is_err_not_empty_ok() {
+        let query = ScoredPostsQuery::default();
+        assert!(query.scoring_sequence.is_none());
+        let refused = PhoenixScorer::refuse_without_sequence(&query, 2).expect("must refuse");
+        assert_eq!(refused.len(), 2);
+        assert!(refused[0].is_err());
+        assert!(refused[1].is_err());
+        assert!(refused[0]
+            .as_ref()
+            .unwrap_err()
+            .contains("scoring_sequence missing"));
+    }
+
+    #[test]
+    fn present_scoring_sequence_does_not_refuse() {
+        let query = ScoredPostsQuery {
+            scoring_sequence: Some(xai_recsys_proto::UserActionSequence::default()),
+            ..Default::default()
+        };
+        assert!(PhoenixScorer::refuse_without_sequence(&query, 1).is_none());
     }
 }

--- a/home-mixer/scorers/phoenix_scores_ranking_scorer.rs
+++ b/home-mixer/scorers/phoenix_scores_ranking_scorer.rs
@@ -21,6 +21,13 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for PhoenixScoresRankingScorer {
         candidates
             .iter()
             .map(|c| {
+                if !RankingScorer::phoenix_heads_present(&c.phoenix_scores) {
+                    return Ok(PostCandidate {
+                        weighted_score: None,
+                        score: None,
+                        ..Default::default()
+                    });
+                }
                 let weighted = RankingScorer::compute_weighted_score(&weights, query, c);
                 Ok(PostCandidate {
                     weighted_score: Some(weighted),
@@ -34,5 +41,46 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for PhoenixScoresRankingScorer {
     fn update(&self, candidate: &mut PostCandidate, scored: PostCandidate) {
         candidate.weighted_score = scored.weighted_score;
         candidate.score = scored.score;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::candidate::PhoenixScores;
+
+    fn query() -> ScoredPostsQuery {
+        let mut query = ScoredPostsQuery::default();
+        let fs = xai_feature_switches::FeatureSwitches::new(vec![]).unwrap();
+        let results = fs.match_recipient(&xai_feature_switches::RecipientBuilder::new().build());
+        query.params = results.into();
+        query
+    }
+
+    #[tokio::test]
+    async fn missing_heads_leave_score_unset() {
+        let scored = PhoenixScoresRankingScorer
+            .score(&query(), &[PostCandidate::default()])
+            .await;
+        let out = scored[0].as_ref().unwrap();
+        assert!(out.score.is_none());
+        assert!(out.weighted_score.is_none());
+    }
+
+    #[tokio::test]
+    async fn zero_favorite_head_still_ranks() {
+        let candidate = PostCandidate {
+            phoenix_scores: PhoenixScores {
+                favorite_score: Some(0.0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let scored = PhoenixScoresRankingScorer
+            .score(&query(), std::slice::from_ref(&candidate))
+            .await;
+        let out = scored[0].as_ref().unwrap();
+        assert!(out.score.is_some());
+        assert!(out.weighted_score.is_some());
     }
 }

--- a/home-mixer/scorers/ranking_scorer.rs
+++ b/home-mixer/scorers/ranking_scorer.rs
@@ -366,6 +366,65 @@ impl RankingScorer {
         score.unwrap_or(0.0) * weight
     }
 
+    // Live sink: PhoenixCandidatePipeline scorers
+    // [PhoenixScorer, RankingScorer, VMRanker] -> TopKScoreSelector.
+    // TopK treats score == None as -inf (drop). A Phoenix lookup miss,
+    // missing scoring_sequence, or >PHOENIX_CLIENT_MAX_CANDIDATES overflow
+    // leaves every head None. apply() used to treat that as 0 and
+    // offset_score wrote Some(NEGATIVE_SCORES_OFFSET), so those posts
+    // still ranked. Some(0.0) is a real prediction and still ranks.
+    pub(crate) fn phoenix_heads_present(scores: &PhoenixScores) -> bool {
+        scores.favorite_score.is_some()
+            || scores.reply_score.is_some()
+            || scores.retweet_score.is_some()
+            || scores.photo_expand_score.is_some()
+            || scores.video_open_score.is_some()
+            || scores.click_score.is_some()
+            || scores.open_link_score.is_some()
+            || scores.profile_click_score.is_some()
+            || scores.vqv_score.is_some()
+            || scores.share_score.is_some()
+            || scores.share_via_dm_score.is_some()
+            || scores.share_via_copy_link_score.is_some()
+            || scores.dwell_score.is_some()
+            || scores.quote_score.is_some()
+            || scores.quoted_click_score.is_some()
+            || scores.quoted_vqv_score.is_some()
+            || scores.dwell_time.is_some()
+            || scores.click_dwell_time.is_some()
+            || scores.active_secs_5m_residual_norm.is_some()
+            || scores.follow_author_score.is_some()
+            || scores.post_unexplored_score.is_some()
+            || scores.not_interested_score.is_some()
+            || scores.block_author_score.is_some()
+            || scores.mute_author_score.is_some()
+            || scores.report_score.is_some()
+            || scores.not_dwelled_score.is_some()
+    }
+
+    fn ranked_update(
+        has_heads: bool,
+        weighted: f64,
+        score: f64,
+        slate_context: Option<SlateContext>,
+    ) -> PostCandidate {
+        if has_heads {
+            PostCandidate {
+                weighted_score: Some(weighted),
+                score: Some(score),
+                slate_context,
+                ..Default::default()
+            }
+        } else {
+            PostCandidate {
+                weighted_score: None,
+                score: None,
+                slate_context,
+                ..Default::default()
+            }
+        }
+    }
+
     pub(crate) fn compute_weighted_score(
         weights: &ScoringWeights,
         query: &ScoredPostsQuery,
@@ -720,12 +779,12 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for RankingScorer {
                 .zip(final_scores)
                 .enumerate()
                 .map(|(i, (&weighted, score))| {
-                    Ok(PostCandidate {
-                        weighted_score: Some(weighted),
-                        score: Some(score),
-                        slate_context: persisted_contexts.as_ref().map(|contexts| contexts[i]),
-                        ..Default::default()
-                    })
+                    Ok(Self::ranked_update(
+                        Self::phoenix_heads_present(&candidates[i].phoenix_scores),
+                        weighted,
+                        score,
+                        persisted_contexts.as_ref().map(|contexts| contexts[i]),
+                    ))
                 })
                 .collect();
         }
@@ -758,12 +817,12 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for RankingScorer {
             .zip(final_scores)
             .enumerate()
             .map(|(i, (&weighted, score))| {
-                Ok(PostCandidate {
-                    weighted_score: Some(weighted),
-                    score: Some(score),
-                    slate_context: persisted_contexts.as_ref().map(|contexts| contexts[i]),
-                    ..Default::default()
-                })
+                Ok(Self::ranked_update(
+                    Self::phoenix_heads_present(&candidates[i].phoenix_scores),
+                    weighted,
+                    score,
+                    persisted_contexts.as_ref().map(|contexts| contexts[i]),
+                ))
             })
             .collect()
     }
@@ -804,10 +863,18 @@ mod tests {
         query
     }
 
+    fn scored_heads() -> PhoenixScores {
+        PhoenixScores {
+            favorite_score: Some(0.0),
+            ..Default::default()
+        }
+    }
+
     fn candidate(author_id: u64, in_network: Option<bool>) -> PostCandidate {
         PostCandidate {
             author_id,
             in_network,
+            phoenix_scores: scored_heads(),
             ..Default::default()
         }
     }
@@ -817,6 +884,7 @@ mod tests {
             author_id,
             in_network,
             in_reply_to_tweet_id: Some(42),
+            phoenix_scores: scored_heads(),
             ..Default::default()
         }
     }
@@ -826,8 +894,69 @@ mod tests {
             author_id,
             in_network,
             retweeted_tweet_id: Some(42),
+            phoenix_scores: scored_heads(),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn phoenix_heads_present_treats_some_zero_as_scored() {
+        assert!(!RankingScorer::phoenix_heads_present(
+            &PhoenixScores::default()
+        ));
+        assert!(RankingScorer::phoenix_heads_present(&PhoenixScores {
+            favorite_score: Some(0.0),
+            ..Default::default()
+        }));
+        assert!(RankingScorer::phoenix_heads_present(&PhoenixScores {
+            report_score: Some(0.0),
+            ..Default::default()
+        }));
+    }
+
+    #[tokio::test]
+    async fn missing_phoenix_heads_leave_score_unset_for_topk_drop() {
+        let scorer = test_scorer();
+        let missing = PostCandidate {
+            author_id: 1,
+            in_network: Some(true),
+            ..Default::default()
+        };
+        let query = query_with_flags(&[("rust_home_mixer_value_model_mode", "weighted")]);
+        let scored = scorer.score(&query, std::slice::from_ref(&missing)).await;
+        let out = scored[0].as_ref().unwrap();
+        assert!(out.score.is_none(), "missing heads must not invent a rank");
+        assert!(out.weighted_score.is_none());
+        assert!(!RankingScorer::phoenix_heads_present(&missing.phoenix_scores));
+    }
+
+    #[tokio::test]
+    async fn zero_favorite_head_still_ranks() {
+        let scorer = test_scorer();
+        let query = query_with_flags(&[("rust_home_mixer_value_model_mode", "weighted")]);
+        let scored = scorer
+            .score(&query, std::slice::from_ref(&candidate(1, Some(true))))
+            .await;
+        let out = scored[0].as_ref().unwrap();
+        assert!(out.score.is_some(), "Some(0.0) is a real Phoenix head");
+        assert!(out.weighted_score.is_some());
+    }
+
+    #[tokio::test]
+    async fn mixed_slate_drops_only_the_unscored_candidate() {
+        let scorer = test_scorer();
+        let candidates = vec![
+            candidate(1, Some(true)),
+            PostCandidate {
+                author_id: 2,
+                in_network: Some(true),
+                ..Default::default()
+            },
+        ];
+        let query = query_with_flags(&[("rust_home_mixer_value_model_mode", "weighted")]);
+        let scored = scorer.score(&query, &candidates).await;
+        assert!(scored[0].as_ref().unwrap().score.is_some());
+        assert!(scored[1].as_ref().unwrap().score.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Bug

Phoenix lookup miss, missing `scoring_sequence`, or overflow past `PHOENIX_CLIENT_MAX_CANDIDATES` leaves every Phoenix head `None`. `RankingScorer::apply` treated that as 0, then `offset_score` wrote `Some(NEGATIVE_SCORES_OFFSET)`. `TopKScoreSelector` only drops `score == None`. Those posts still ranked.

`Some(0.0)` is a real Phoenix prediction and still ranks.

This is not #3 (ranker xDS). This is not #31 (author-size IPS). This is not a taste weight tweak.

## Five-line proof

- Entry: `PhoenixScorer` / `predictions.candidate_scores` leave all heads None on miss
- Sink: `PhoenixCandidatePipeline` scorers `[PhoenixScorer, RankingScorer, VMRanker]` then `TopKScoreSelector` (`score.unwrap_or(NEG_INFINITY)`)
- Break: `apply(None) = 0` plus offset wrote a finite rank for an unscored post
- Viewer effect: For You could serve a tweet Phoenix never scored, including overflow and no-sequence requests
- Twin: scorer `update_all` already skips `Err`; prediction failure already returned `Err`

## Change

- `RankingScorer` and `PhoenixScoresRankingScorer`: no heads -> `score` / `weighted_score` stay `None`
- `PhoenixScorer`: missing `scoring_sequence` returns `Err` so `update_all` does not stamp empty scores or `last_scored_at_ms`

## Tests

- Default heads: score unset
- `Some(0.0)` favorite: still ranks
- Mixed slate: only the unscored candidate is unset
- Missing sequence: Err, not Ok(default)

`cargo test` cannot run. Public dump has no home-mixer crate manifest.

Fork PR: none
