### PR TITLE
Drop quotes, retweets, and replies whose ancillary VF verdict is Interstitial

### DIFF
--- a/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
@@ -176,9 +176,132 @@ pub(crate) fn should_drop_ancillary(
 
 fn should_drop_reason(reason: &FilteredReason) -> bool {
     match reason {
-        FilteredReason::SafetyResult(safety_result) => {
-            matches!(safety_result.action, Action::Drop(_))
-        }
-        _ => true, 
+        FilteredReason::SafetyResult(safety_result) => matches!(
+            safety_result.action,
+            // Keep-and-warn is only wired for the primary card (`visibility_reason`).
+            // An ancillary Interstitial is discarded, so the wrapper would serve
+            // NSFW/gore as a normal Allow embed. Drop the quote / RT / reply instead.
+            Action::Drop(_) | Action::Interstitial
+        ),
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_visibility_filtering::models::SafetyResult;
+
+    fn interstitial() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: None,
+            action: Action::Interstitial,
+        })
+    }
+
+    fn allow() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: None,
+            action: Action::Allow,
+        })
+    }
+
+    fn drop_action() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: None,
+            action: Action::Drop(Default::default()),
+        })
+    }
+
+    fn results(pairs: Vec<(u64, FilteredReason)>) -> HashMap<u64, Result<Option<FilteredReason>>> {
+        pairs
+            .into_iter()
+            .map(|(id, reason)| (id, Ok(Some(reason))))
+            .collect()
+    }
+
+    #[test]
+    fn interstitial_on_quoted_sets_drop_ancillary() {
+        let quote = PostCandidate {
+            tweet_id: 1,
+            quoted_tweet_id: Some(10),
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(&quote, &results(vec![(10, interstitial())])));
+    }
+
+    #[test]
+    fn interstitial_on_retweet_source_sets_drop_ancillary() {
+        let repost = PostCandidate {
+            tweet_id: 1,
+            retweeted_tweet_id: Some(10),
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(
+            &repost,
+            &results(vec![(10, interstitial())])
+        ));
+    }
+
+    #[test]
+    fn interstitial_on_ancestor_sets_drop_ancillary() {
+        let reply = PostCandidate {
+            tweet_id: 1,
+            ancestors: vec![10],
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(
+            &reply,
+            &results(vec![(10, interstitial())])
+        ));
+    }
+
+    #[test]
+    fn tombstoned_ancestor_interstitial_is_skipped() {
+        let reply = PostCandidate {
+            tweet_id: 1,
+            ancestors: vec![10],
+            tombstone_ancestor_ids: vec![10],
+            ..Default::default()
+        };
+        assert!(!should_drop_ancillary(
+            &reply,
+            &results(vec![(10, interstitial())])
+        ));
+    }
+
+    #[test]
+    fn allow_on_ancillary_does_not_drop() {
+        let quote = PostCandidate {
+            tweet_id: 1,
+            quoted_tweet_id: Some(10),
+            ..Default::default()
+        };
+        assert!(!should_drop_ancillary(&quote, &results(vec![(10, allow())])));
+    }
+
+    #[test]
+    fn drop_on_ancillary_still_drops() {
+        let quote = PostCandidate {
+            tweet_id: 1,
+            quoted_tweet_id: Some(10),
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(
+            &quote,
+            &results(vec![(10, drop_action())])
+        ));
+    }
+
+    #[test]
+    fn primary_interstitial_without_ancillary_does_not_set_drop_flag() {
+        let primary = PostCandidate {
+            tweet_id: 1,
+            ..Default::default()
+        };
+        assert!(!should_drop_ancillary(
+            &primary,
+            &results(vec![(1, interstitial())])
+        ));
     }
 }


### PR DESCRIPTION
## Bug

#134 leftover. Quote / RT / ancestor `Action::Interstitial` does not set `drop_ancillary_posts`. Verified on `xai-org/main` (`902a06f`).

`should_drop_reason` only matched `Action::Drop`. Home NSFW / gore / card / nsfw-author rules emit Interstitial. Recs has Drop twins, but RT sources are fetched at `TimelineHome`, and a dual-role id is overwritten by the Home Interstitial. `AncillaryVFFilter` reads the flag. The wrapper `visibility_reason` is the primary Allow. Mixer serializes only that. This repo does not draw an interstitial.

This is not #115 (Following quotes at Home vs Recs). Not #119 (RT primary looked up by wrapper id). Not #121 (VF `Err` / missing key). #121 leftover text called this Interstitial≠Drop path out. #134 left it as keep-and-warn. Keep-and-warn is only real on the primary card.

## Five-line proof

- Entry: `VFCandidateHydrator::should_drop_reason` (quote / RT / ancestor lookups in `should_drop_ancillary`)
- Sink: `AncillaryVFFilter` (`drop_ancillary_posts`); `candidates_to_scored_posts` writes only primary `visibility_reason`
- Break: `Action::Interstitial` on a child did not set the flag; wrapper stayed Allow
- Viewer effect: a followee RT (or quote/reply) of NSFW / gore serves as a normal For You / Following card with the media embed and no warn
- Twin: Recs Drop twins already drop the same labels when the child is fetched at `TimelineHomeRecommendations`. Primary Interstitial still keep-and-warn via `VFFilter` / `visibility_reason`

## Change

Treat `Action::Interstitial` like `Action::Drop` for ancillary children only. Primary Interstitial is unchanged.

## Tests

- Quote / RT / ancestor Interstitial → `drop_ancillary_posts`
- Tombstoned ancestor Interstitial still skipped
- Ancillary Allow keeps; ancillary Drop still drops
- Primary Interstitial with no child does not set the flag

Standalone decision-table harness (same match arms): 9/9 passed.

`cargo test` cannot run. Public dump has no Home Mixer manifest.

Fork PR: none