### PR TITLE
Fail closed when TES edit-control lookup is Err or missing

### DIFF
--- a/visibility-filtering/hydration/tes_hydrator.rs
+++ b/visibility-filtering/hydration/tes_hydrator.rs
@@ -1,4 +1,4 @@
-use crate::hydration::batch::TweetHydrationBatch;
+use crate::hydration::batch::{Hydrated, TweetHydrationBatch};
 use crate::hydration::metrics::{record_batch_size, timed_keyed_rpc, timed_results};
 use crate::models::{
     CoreFeature, MediaFeature, NsfwFeature, TweetCandidateInput, TweetFeatures, TweetId,
@@ -183,6 +183,10 @@ fn build_tweet_features(
         admin: tweet_keyed.nsfw_admin.get(&id).copied().unwrap_or(false),
     };
     let edit_control = tweet_keyed.edit_control.get(&id).cloned();
+    let edit_control_lookup_failed = matches!(
+        tweet_keyed.edit_control.hydrated(&id),
+        Some(Hydrated::Failed(_))
+    );
 
     core_datas
         .get(&tweet_id)
@@ -197,8 +201,12 @@ fn build_tweet_features(
             is_nullcast,
             is_community_tweet,
             edit_control,
+            edit_control_lookup_failed,
         })
-        .unwrap_or_default()
+        .unwrap_or(TweetFeatures {
+            edit_control_lookup_failed,
+            ..Default::default()
+        })
 }
 
 fn media_feature(entities: MediaEntities) -> MediaFeature {
@@ -473,5 +481,116 @@ mod tests {
         let f = &features[&TweetId(10)];
         assert!(f.core.text.is_empty());
         assert!(!f.media.has_media);
+    }
+
+    fn not_found_edit(id: u64) -> TweetHydrationBatch<EditControl> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(TweetId(id), Ok::<_, anyhow::Error>(None))]),
+        )
+    }
+
+    fn failed_edit(id: u64) -> TweetHydrationBatch<EditControl> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(
+                TweetId(id),
+                Err::<Option<EditControl>, _>("tes unavailable"),
+            )]),
+        )
+    }
+
+    fn current_edit(id: u64) -> TweetHydrationBatch<EditControl> {
+        found(
+            id,
+            EditControl::Initial(xai_core_entities::entities::EditControlInitial {
+                edit_tweet_ids: vec![id],
+                ..Default::default()
+            }),
+        )
+    }
+
+    #[test]
+    fn assemble_stamps_edit_control_lookup_failed_on_tes_err() {
+        let candidates = vec![candidate(10, 100)];
+        let core_datas = HashMap::from([(
+            TweetId(10),
+            PureCoreData {
+                author_id: 100,
+                ..Default::default()
+            },
+        )]);
+        let tweet_keyed = TweetHydration {
+            edit_control: failed_edit(10),
+            ..Default::default()
+        };
+
+        let features = hydrator().assemble_tweet_features(&candidates, &core_datas, &tweet_keyed);
+
+        assert!(features[&TweetId(10)].edit_control_lookup_failed);
+        assert!(features[&TweetId(10)].edit_control.is_none());
+    }
+
+    #[test]
+    fn assemble_does_not_stamp_edit_control_lookup_failed_on_not_found() {
+        let candidates = vec![candidate(10, 100)];
+        let core_datas = HashMap::from([(
+            TweetId(10),
+            PureCoreData {
+                author_id: 100,
+                ..Default::default()
+            },
+        )]);
+        let tweet_keyed = TweetHydration {
+            edit_control: not_found_edit(10),
+            ..Default::default()
+        };
+
+        let features = hydrator().assemble_tweet_features(&candidates, &core_datas, &tweet_keyed);
+
+        assert!(!features[&TweetId(10)].edit_control_lookup_failed);
+        assert!(features[&TweetId(10)].edit_control.is_none());
+    }
+
+    #[test]
+    fn assemble_keeps_found_edit_control_and_does_not_fail() {
+        let candidates = vec![candidate(10, 100)];
+        let core_datas = HashMap::from([(
+            TweetId(10),
+            PureCoreData {
+                author_id: 100,
+                ..Default::default()
+            },
+        )]);
+        let tweet_keyed = TweetHydration {
+            edit_control: current_edit(10),
+            ..Default::default()
+        };
+
+        let features = hydrator().assemble_tweet_features(&candidates, &core_datas, &tweet_keyed);
+
+        assert!(!features[&TweetId(10)].edit_control_lookup_failed);
+        assert!(features[&TweetId(10)].edit_control.is_some());
+    }
+
+    #[test]
+    fn assemble_stamps_edit_control_lookup_failed_when_core_missing() {
+        let candidates = vec![resolve_candidate(
+            &RawCandidate {
+                tweet_id: TweetId(10),
+                request_author_id: Some(100),
+            },
+            &HashMap::new(),
+        )
+        .unwrap()];
+        let tweet_keyed = TweetHydration {
+            edit_control: failed_edit(10),
+            ..Default::default()
+        };
+
+        let features =
+            hydrator().assemble_tweet_features(&candidates, &HashMap::new(), &tweet_keyed);
+
+        assert!(features[&TweetId(10)].edit_control_lookup_failed);
     }
 }

--- a/visibility-filtering/models/mod.rs
+++ b/visibility-filtering/models/mod.rs
@@ -119,6 +119,9 @@ impl HydratedTweetCandidate {
     }
 
     pub fn is_stale_tweet(&self) -> bool {
+        if self.tweet_features.edit_control_lookup_failed {
+            return true;
+        }
         let Some(ec) = &self.tweet_features.edit_control else {
             return false;
         };
@@ -127,13 +130,16 @@ impl HydratedTweetCandidate {
             xai_core_entities::entities::EditControl::Edit(edit) => {
                 match &edit.edit_control_initial {
                     Some(initial) => &initial.edit_tweet_ids,
-                    None => return false,
+                    // Missing initial ACL: cannot prove this version is current.
+                    None => return true,
                 }
             }
         };
-        edit_tweet_ids
-            .last()
-            .is_some_and(|&last| last != self.tweet_id)
+        match edit_tweet_ids.last() {
+            Some(&last) => last != self.tweet_id,
+            // Empty chain: cannot prove this version is current.
+            None => true,
+        }
     }
 }
 
@@ -266,6 +272,24 @@ mod tests {
     }
 
     #[test]
+    fn is_stale_tweet_when_edit_control_lookup_failed() {
+        let mut c = candidate();
+        c.tweet_features.edit_control_lookup_failed = true;
+        assert!(c.is_stale_tweet());
+    }
+
+    #[test]
+    fn is_stale_tweet_when_edit_chain_empty() {
+        use xai_core_entities::entities::{EditControl, EditControlInitial};
+        let mut c = candidate();
+        c.tweet_features.edit_control = Some(EditControl::Initial(EditControlInitial {
+            edit_tweet_ids: vec![],
+            ..Default::default()
+        }));
+        assert!(c.is_stale_tweet());
+    }
+
+    #[test]
     fn is_stale_tweet_edit_variant_superseded() {
         use xai_core_entities::entities::{EditControl, EditControlEdit, EditControlInitial};
         let mut c = HydratedTweetCandidate {
@@ -295,6 +319,6 @@ mod tests {
             initial_tweet_id: 10,
             edit_control_initial: None,
         }));
-        assert!(!c.is_stale_tweet());
+        assert!(c.is_stale_tweet());
     }
 }

--- a/visibility-filtering/models/tweet.rs
+++ b/visibility-filtering/models/tweet.rs
@@ -31,4 +31,7 @@ pub struct TweetFeatures {
     pub is_nullcast: bool,
     pub is_community_tweet: bool,
     pub edit_control: Option<xai_core_entities::entities::EditControl>,
+    /// TES `get_edit_control` was Failed (timeout / RPC / missing id).
+    /// Distinct from `edit_control: None` (genuine NotFound: never edited).
+    pub edit_control_lookup_failed: bool,
 }

--- a/visibility-filtering/rules/golden_corpus.rs
+++ b/visibility-filtering/rules/golden_corpus.rs
@@ -546,6 +546,29 @@ fn tweet_shape_cases() -> Vec<Case> {
             expected_decided_by: Some("DropStaleTweetsRule"),
         },
         Case {
+            name: "stale_edit_control_lookup_failed_drops",
+            level: TimelineHome,
+            viewer: viewer(VIEWER_ID),
+            candidate: tweet_candidate(|t| t.edit_control_lookup_failed = true),
+            expected_action: Drop(FilteredReason::UnspecifiedReason),
+            expected_decided_by: Some("DropStaleTweetsRule"),
+        },
+        Case {
+            name: "stale_edit_control_missing_initial_drops",
+            level: TimelineHome,
+            viewer: viewer(VIEWER_ID),
+            candidate: tweet_candidate(|t| {
+                t.edit_control = Some(EditControl::Edit(
+                    xai_core_entities::entities::EditControlEdit {
+                        initial_tweet_id: 1,
+                        edit_control_initial: None,
+                    },
+                ))
+            }),
+            expected_action: Drop(FilteredReason::UnspecifiedReason),
+            expected_decided_by: Some("DropStaleTweetsRule"),
+        },
+        Case {
             name: "legal_takedown_drops_in_withheld_country",
             level: TimelineHome,
             viewer: viewer_in_country("us"),

--- a/visibility-filtering/rules/tweet_rules.rs
+++ b/visibility-filtering/rules/tweet_rules.rs
@@ -801,6 +801,27 @@ mod tests {
             .build();
         assert_drops(stale, &viewer(VIEWER_ID), &stale_c, &reason);
         assert_allows(stale, &viewer(VIEWER_ID), &candidate().build());
+        let failed_lookup = candidate()
+            .with_tweet_features(TweetFeatures {
+                edit_control_lookup_failed: true,
+                ..Default::default()
+            })
+            .build();
+        assert_drops(stale, &viewer(VIEWER_ID), &failed_lookup, &reason);
+        assert_drops(stale, &author_viewer(), &failed_lookup, &reason);
+        assert_drops(stale, &logged_out_viewer(), &failed_lookup, &reason);
+        let missing_initial = candidate()
+            .with_tweet_features(TweetFeatures {
+                edit_control: Some(EditControl::Edit(
+                    xai_core_entities::entities::EditControlEdit {
+                        initial_tweet_id: 1,
+                        edit_control_initial: None,
+                    },
+                )),
+                ..Default::default()
+            })
+            .build();
+        assert_drops(stale, &viewer(VIEWER_ID), &missing_initial, &reason);
         let stale_rt = candidate()
             .with_tweet_features(TweetFeatures {
                 edit_control: stale_edit_control(),


### PR DESCRIPTION
TES `get_edit_control` timeout or per-id `Err` was collapsed to `edit_control = None`. `is_stale_tweet` treats `None` as current and Allows. `EditControl::Edit` with no `edit_control_initial` did the same.

This is not #134 (NSFW / takedown / nullcast / media TES flags). #134 leftover left edit-control out. Not #141 (exclusive TES). ConversationControl / TrustedFriends / MentionFilter have no TES hydrator on this dump (schema-only).

- Entry: `TesHydrator::hydrate_tweets` → `get_edit_control` (`timed_results` already Found / NotFound / Failed)
- Sink: `DropStaleTweetsRule` (`is_stale() && !is_retweet()`). Wired on TimelineHome and TimelineHomeRecommendations via `TES_HOME_DROPS` / `VFFilter`.
- Break: Failed TES edit-control RPC or omitted id assembled as not-stale. Missing `edit_control_initial` on the Edit variant also assembled as current.
- Viewer effect: a superseded / edited post ranks as the current card on For You and Latest Following.
- Twin: Genuine `Ok(None)` (never edited) is unchanged.

Stamp `edit_control_lookup_failed` when the edit-control slot is Failed. `is_stale_tweet` Drops Failed, empty edit chains, and Edit-without-initial. `DropStaleTweetsRule` already drops stale non-retweets.

- Assemble stamps lookup-failed on TES Err; NotFound stays not failed; Found current stays current
- Failed still stamps when core data is missing
- `is_stale_tweet` true for lookup-failed, empty chain, and Edit-without-initial
- `DropStaleTweetsRule` drops Failed for viewer, author, and logged-out
- Golden corpus: `stale_edit_control_lookup_failed_drops`, `stale_edit_control_missing_initial_drops`

Standalone decision-table harness (same Found / NotFound / Failed / missing-initial arms): 12/12 passed.

`cargo test` cannot run. Public dump has no visibility-filtering / Home Mixer manifest.

ConversationControl / TrustedFriends / MentionFilter are schema-only (thunder tweet/user). No TES RPC on this dump to hydrate an ACL. Exclusive TES fail-closed is #141. DropStaleTweetsRule still Allows stale retweets.

Fork PR: none