### PR TITLE
Fail closed when TES edit_control lookup is Err

### DIFF
--- a/visibility-filtering/hydration/mod.rs
+++ b/visibility-filtering/hydration/mod.rs
@@ -25,7 +25,7 @@ use safety_label_hydrator::{SafetyLabelHydration, SafetyLabelHydrator};
 use socialgraph_hydrator::SocialgraphHydrator;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tes_hydrator::TesHydrator;
+use tes_hydrator::{retain_candidates_with_usable_edit_control, TesHydrator};
 use viewer_hydrator::ViewerHydrator;
 use xai_core_entities::gizmoduck_client::GizmoduckClient;
 use xai_core_entities::tweet_entity_service_client::TESClient;
@@ -207,6 +207,8 @@ impl HydrationPipeline {
                 label_response,
             } = safety_labels;
 
+            let candidates =
+                retain_candidates_with_usable_edit_control(candidates, &tes_tweet_keyed);
             let tweet_features = self.tes_hydrator.assemble_tweet_features(
                 &candidates,
                 &core_datas,

--- a/visibility-filtering/hydration/tes_hydrator.rs
+++ b/visibility-filtering/hydration/tes_hydrator.rs
@@ -1,4 +1,4 @@
-use crate::hydration::batch::TweetHydrationBatch;
+use crate::hydration::batch::{Hydrated, TweetHydrationBatch};
 use crate::hydration::metrics::{record_batch_size, timed_keyed_rpc, timed_results};
 use crate::models::{
     CoreFeature, MediaFeature, NsfwFeature, TweetCandidateInput, TweetFeatures, TweetId,
@@ -26,6 +26,26 @@ pub(crate) struct TweetHydration {
     pub(crate) takedown_reasons: TweetHydrationBatch<Vec<TakedownReason>>,
     pub(crate) edit_control: TweetHydrationBatch<EditControl>,
     pub(crate) media: TweetHydrationBatch<MediaFeature>,
+}
+
+impl TweetHydration {
+    /// TES `get_edit_control` Failed must not assemble as `None`.
+    /// `is_stale_tweet` treats missing edit control as current, so a stale
+    /// tombstone (pre-edit labeled text) would serve. Genuine NotFound
+    /// (never edited) is not Failed.
+    pub(crate) fn edit_control_lookup_failed(&self, id: TweetId) -> bool {
+        matches!(self.edit_control.hydrated(&id), Some(Hydrated::Failed(_)))
+    }
+}
+
+pub(crate) fn retain_candidates_with_usable_edit_control(
+    candidates: Vec<TweetCandidateInput>,
+    tweet_keyed: &TweetHydration,
+) -> Vec<TweetCandidateInput> {
+    candidates
+        .into_iter()
+        .filter(|c| !tweet_keyed.edit_control_lookup_failed(c.tweet_id))
+        .collect()
 }
 
 impl TesHydrator {
@@ -473,5 +493,113 @@ mod tests {
         let f = &features[&TweetId(10)];
         assert!(f.core.text.is_empty());
         assert!(!f.media.has_media);
+    }
+
+    fn found_edit_control(id: u64) -> TweetHydrationBatch<EditControl> {
+        found(id, EditControl::Initial(Default::default()))
+    }
+
+    fn not_found_edit_control(id: u64) -> TweetHydrationBatch<EditControl> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(TweetId(id), Ok::<_, anyhow::Error>(None))]),
+        )
+    }
+
+    fn failed_edit_control(id: u64) -> TweetHydrationBatch<EditControl> {
+        TweetHydrationBatch::from_results(
+            [TweetId(id)],
+            HashMap::from([(
+                TweetId(id),
+                Err::<Option<EditControl>, _>("tes unavailable"),
+            )]),
+        )
+    }
+
+    #[test]
+    fn edit_control_lookup_failed_is_false_when_found_or_not_found() {
+        let found = TweetHydration {
+            edit_control: found_edit_control(10),
+            ..Default::default()
+        };
+        let not_found = TweetHydration {
+            edit_control: not_found_edit_control(10),
+            ..Default::default()
+        };
+
+        assert!(!found.edit_control_lookup_failed(TweetId(10)));
+        assert!(!not_found.edit_control_lookup_failed(TweetId(10)));
+        assert!(!TweetHydration::default().edit_control_lookup_failed(TweetId(10)));
+    }
+
+    #[test]
+    fn assemble_collapses_failed_edit_control_to_none() {
+        let candidates = vec![candidate(10, 100)];
+        let core_datas = HashMap::from([(
+            TweetId(10),
+            PureCoreData {
+                author_id: 100,
+                ..Default::default()
+            },
+        )]);
+        let tweet_keyed = TweetHydration {
+            edit_control: failed_edit_control(10),
+            ..Default::default()
+        };
+
+        let features = hydrator().assemble_tweet_features(&candidates, &core_datas, &tweet_keyed);
+
+        assert!(features[&TweetId(10)].edit_control.is_none());
+    }
+
+    #[test]
+    fn failed_edit_control_lookup_is_edit_failure() {
+        let keyed = TweetHydration {
+            edit_control: failed_edit_control(10),
+            ..Default::default()
+        };
+
+        assert!(keyed.edit_control_lookup_failed(TweetId(10)));
+        assert!(!keyed.edit_control_lookup_failed(TweetId(11)));
+    }
+
+    #[test]
+    fn timed_out_edit_control_batch_is_edit_failure() {
+        let keyed = TweetHydration {
+            edit_control: TweetHydrationBatch::timed_out([TweetId(10)]),
+            ..Default::default()
+        };
+
+        assert!(keyed.edit_control_lookup_failed(TweetId(10)));
+    }
+
+    #[test]
+    fn retain_drops_only_ids_whose_edit_control_rpc_failed() {
+        let keyed = TweetHydration {
+            edit_control: TweetHydrationBatch::from_results(
+                [TweetId(10), TweetId(11), TweetId(12)],
+                HashMap::from([
+                    (
+                        TweetId(10),
+                        Err::<Option<EditControl>, _>("tes unavailable"),
+                    ),
+                    (TweetId(11), Ok::<_, anyhow::Error>(None)),
+                    (
+                        TweetId(12),
+                        Ok::<_, anyhow::Error>(Some(EditControl::Initial(Default::default()))),
+                    ),
+                ]),
+            ),
+            ..Default::default()
+        };
+        let kept = retain_candidates_with_usable_edit_control(
+            vec![candidate(10, 100), candidate(11, 100), candidate(12, 100)],
+            &keyed,
+        );
+
+        assert_eq!(
+            kept.iter().map(|c| c.tweet_id.0).collect::<Vec<_>>(),
+            vec![11, 12]
+        );
     }
 }


### PR DESCRIPTION
## Five-line proof

- Entry: `TesHydrator::hydrate_tweets` `get_edit_control` (`timed_results` Found / NotFound / Failed)
- Sink: omit-from-hydrate → `FilterTweets` `Verdict::unresolved_author` Drop
- Break: Failed assembled as `edit_control = None`; `is_stale_tweet` treats None as current
- Viewer effect: a superseded pre-edit tombstone (labeled old text) still serves
- Twin: #134 fail-closes TES nsfw / takedown / nullcast / media. `edit_control` was the leftover.

Genuine `NotFound` / `Ok(None)` (never edited) is unchanged.

`retain_candidates_with_usable_edit_control` drops Failed ids before assemble.

Tests: Found / NotFound / empty batch stay; Failed RPC and timeout drop; retain keeps only usable ids; assemble still collapses Failed to None.

Standalone decision-table harness (same match arms): 12/12 passed.

`cargo test` cannot run. Public dump has no visibility-filtering crate manifest.

Fork PR: none