### PR TITLE
Include quoted_tweet_id in seen/served related-post ids

### DIFF
--- a/home-mixer/filters/previously_seen_posts_backup_filter.rs
+++ b/home-mixer/filters/previously_seen_posts_backup_filter.rs
@@ -88,4 +88,25 @@ mod tests {
         assert!(result.kept.is_empty());
         assert!(result.removed.is_empty());
     }
+
+    #[test]
+    fn test_filters_quote_of_impressed_original() {
+        let query = ScoredPostsQuery {
+            impressed_post_ids: vec![99],
+            ..Default::default()
+        };
+
+        let quote = PostCandidate {
+            tweet_id: 7,
+            quoted_tweet_id: Some(99),
+            ..Default::default()
+        };
+        let unrelated = make_candidate(8);
+
+        let result = PreviouslySeenPostsBackupFilter.filter(&query, vec![quote, unrelated]);
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 8);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 7);
+    }
 }

--- a/home-mixer/util/candidates_util.rs
+++ b/home-mixer/util/candidates_util.rs
@@ -7,6 +7,7 @@ pub fn get_related_post_ids(candidate: &PostCandidate) -> Vec<u64> {
     let mut ids = vec![candidate.tweet_id];
     ids.extend(candidate.retweeted_tweet_id);
     ids.extend(candidate.in_reply_to_tweet_id);
+    ids.extend(candidate.quoted_tweet_id);
     ids
 }
 
@@ -14,6 +15,7 @@ pub fn related_post_ids_iter(candidate: &PostCandidate) -> impl Iterator<Item = 
     std::iter::once(candidate.tweet_id)
         .chain(candidate.retweeted_tweet_id)
         .chain(candidate.in_reply_to_tweet_id)
+        .chain(candidate.quoted_tweet_id)
 }
 
 pub fn vqv_weight(
@@ -106,5 +108,33 @@ mod tests {
             ..Default::default()
         };
         assert!((quoted_vqv_weight(&candidate, 10_000, 0.5, true)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn related_ids_include_quoted_tweet_as_same_card() {
+        let candidate = PostCandidate {
+            tweet_id: 10,
+            retweeted_tweet_id: Some(20),
+            in_reply_to_tweet_id: Some(30),
+            quoted_tweet_id: Some(40),
+            ..Default::default()
+        };
+        assert_eq!(
+            related_post_ids_iter(&candidate).collect::<Vec<_>>(),
+            vec![10, 20, 30, 40]
+        );
+        assert_eq!(get_related_post_ids(&candidate), vec![10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn related_ids_skip_absent_quote() {
+        let candidate = PostCandidate {
+            tweet_id: 10,
+            ..Default::default()
+        };
+        assert_eq!(
+            related_post_ids_iter(&candidate).collect::<Vec<_>>(),
+            vec![10]
+        );
     }
 }


### PR DESCRIPTION
`related_post_ids_iter` walked tweet/retweet/reply ids only, so seen/served filters missed quote-as-same-card.
QuoteHydrator fills `quoted_tweet_id` before PreviouslySeen, PreviouslySeenBackup, and PreviouslyServed.
Chain `quoted_tweet_id` next to retweet and reply. Leftover of #138, not a Thunder delete.
Tests: iterator includes the quote; backup filter drops a quote of an impressed original. Standalone 5/5.
home-mixer has no Cargo.toml in this snapshot.