### PR TITLE
Stop SubscriptionHydrator from skipping exclusive ids on retweets

### DIFF
--- a/home-mixer/candidate_hydrators/subscription_hydrator.rs
+++ b/home-mixer/candidate_hydrators/subscription_hydrator.rs
@@ -1,5 +1,5 @@
 use crate::clients::tweet_entity_service_client::TESClient;
-use crate::models::candidate::PostCandidate;
+use crate::models::candidate::{CandidateHelpers, PostCandidate};
 use crate::models::query::ScoredPostsQuery;
 use std::sync::Arc;
 use tonic::async_trait;
@@ -31,7 +31,7 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for SubscriptionHydrator {
         &self.cache
     }
     fn cache_key(&self, candidate: &PostCandidate) -> Self::CacheKey {
-        candidate.tweet_id
+        candidate.get_original_tweet_id()
     }
 
     fn cache_value(&self, hydrated: &PostCandidate) -> Self::CacheValue {
@@ -52,7 +52,7 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for SubscriptionHydrator {
     ) -> Vec<Result<PostCandidate, String>> {
         let client = &self.tes_client;
 
-        let tweet_ids: Vec<u64> = candidates.iter().map(|c| c.tweet_id).collect();
+        let tweet_ids = subscription_fetch_ids(candidates);
 
         let post_features = client.get_subscription_author_ids(tweet_ids.clone()).await;
 
@@ -78,5 +78,46 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for SubscriptionHydrator {
 
     fn update(&self, candidate: &mut PostCandidate, hydrated: PostCandidate) {
         candidate.subscription_author_id = hydrated.subscription_author_id;
+    }
+}
+
+fn subscription_fetch_ids(candidates: &[PostCandidate]) -> Vec<u64> {
+    candidates
+        .iter()
+        .map(|c| c.get_original_tweet_id())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_exclusive_still_uses_candidate_id() {
+        let candidates = vec![PostCandidate {
+            tweet_id: 20,
+            ..Default::default()
+        }];
+        assert_eq!(subscription_fetch_ids(&candidates), vec![20]);
+    }
+
+    #[test]
+    fn retweet_of_exclusive_uses_original_tweet_id() {
+        let candidates = vec![PostCandidate {
+            tweet_id: 10,
+            retweeted_tweet_id: Some(20),
+            ..Default::default()
+        }];
+        assert_eq!(subscription_fetch_ids(&candidates), vec![20]);
+    }
+
+    #[test]
+    fn wrapper_id_is_not_the_tes_key() {
+        let candidates = vec![PostCandidate {
+            tweet_id: 10,
+            retweeted_tweet_id: Some(20),
+            ..Default::default()
+        }];
+        assert_ne!(subscription_fetch_ids(&candidates), vec![10]);
     }
 }


### PR DESCRIPTION
Phoenix `SubscriptionHydrator` asks TES for exclusive authors by wrapper `tweet_id`. Super Follow lives on the original. A retweet wrapper is not exclusive, so `subscription_author_id` stays None and `IneligibleSubscriptionFilter` keeps the card.

- Entry: Phoenix `SubscriptionHydrator` (`phoenix_candidate_pipeline.rs`)
- Sink: `IneligibleSubscriptionFilter` keeps `subscription_author_id: None` as public
- Break: TES and cache keyed by `candidate.tweet_id` instead of `get_original_tweet_id()`
- Viewer effect: subscriber RT of an exclusive post still serves on For You to non-subscribers
- Twin: `MediaInfoHydrator`, `LanguageCodeHydrator`, `EngagementCountsHydrator` already fetch by original; QuoteHydrator is #118

This is not #118 (quoted ids). This is not #129 (subscription-list miss). This is not #141 (TES fail-closed).

Look up and cache TES exclusive authors by `candidate.get_original_tweet_id()`. Native exclusive posts are unchanged. Two retweets of the same exclusive now share the cache key.

- Native exclusive still keys TES by the candidate id
- Retweet of exclusive keys TES by the original id (fails on unmodified main)
- TES keyed only by the wrapper id does not treat the retweet as exclusive

`cargo test` cannot run. Public dump has no Home Mixer manifest.

Fork PR: none
Survey: #96–#142. Unclaimed.