### PR TITLE
Fail closed when gizmoduck viewer-age lookup errors

### DIFF
--- a/visibility-filtering/hydration/viewer_hydrator.rs
+++ b/visibility-filtering/hydration/viewer_hydrator.rs
@@ -61,12 +61,12 @@ impl ViewerHydrator {
                         )
                     }
                     Ok(Err(e)) => {
-                        warn!(error = %e, "Gizmoduck viewer lookup failed; failing open");
-                        (false, ViewerAge::Unknown, None)
+                        warn!(error = %e, "Gizmoduck viewer lookup failed; failing closed on age");
+                        (false, ViewerAge::LookupFailed, None)
                     }
                     Err(_) => {
-                        warn!("Gizmoduck viewer lookup timed out; failing open");
-                        (false, ViewerAge::Unknown, None)
+                        warn!("Gizmoduck viewer lookup timed out; failing closed on age");
+                        (false, ViewerAge::LookupFailed, None)
                     }
                 }
             }
@@ -175,23 +175,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rpc_error_fails_open_to_logged_in_defaults() {
+    async fn rpc_error_fails_closed_on_age() {
         let viewer = hydrate_with_broken_client(ViewerLookup::Fails).await;
 
         assert_eq!(viewer.viewer, Viewer::LoggedIn(123));
         assert!(!viewer.allows_sensitive_media);
-        assert_eq!(viewer.viewer_age, ViewerAge::Unknown);
+        assert_eq!(viewer.viewer_age, ViewerAge::LookupFailed);
+        assert!(viewer.viewer_age_lookup_failed());
+        assert!(!viewer.viewer_is_underage());
+        assert!(!viewer.viewer_has_no_stated_age());
         assert_eq!(viewer.account_country_code, None);
         assert_eq!(viewer.country_code.as_deref(), Some("us"));
     }
 
     #[tokio::test]
-    async fn rpc_timeout_fails_open_to_logged_in_defaults() {
+    async fn rpc_timeout_fails_closed_on_age() {
         let viewer = hydrate_with_broken_client(ViewerLookup::Hangs).await;
 
         assert_eq!(viewer.viewer, Viewer::LoggedIn(123));
         assert!(!viewer.allows_sensitive_media);
-        assert_eq!(viewer.viewer_age, ViewerAge::Unknown);
+        assert_eq!(viewer.viewer_age, ViewerAge::LookupFailed);
+        assert!(viewer.viewer_age_lookup_failed());
         assert_eq!(viewer.account_country_code, None);
         assert_eq!(viewer.country_code.as_deref(), Some("us"));
     }

--- a/visibility-filtering/models/viewer.rs
+++ b/visibility-filtering/models/viewer.rs
@@ -20,6 +20,9 @@ pub const ADULT_AGE_YEARS: i32 = 18;
 pub enum ViewerAge {
     Known(i32),
     NotStated,
+    /// Gizmoduck viewer RPC errored or timed out. Distinct from `Unknown`
+    /// (no such user) so age gates can fail closed instead of serving NSFW.
+    LookupFailed,
     #[default]
     Unknown,
 }
@@ -40,6 +43,13 @@ impl ViewerFeatures {
 
     pub fn viewer_has_no_stated_age(&self) -> bool {
         matches!(self.viewer, Viewer::LoggedIn(_)) && self.viewer_age == ViewerAge::NotStated
+    }
+
+    /// Viewer age could not be confirmed because gizmoduck failed. Sensitive
+    /// media must hard-drop globally (same sink as underage), not fail open
+    /// as `Unknown` and not jurisdiction-scope as `NotStated`.
+    pub fn viewer_age_lookup_failed(&self) -> bool {
+        matches!(self.viewer, Viewer::LoggedIn(_)) && self.viewer_age == ViewerAge::LookupFailed
     }
 }
 

--- a/visibility-filtering/rules/context.rs
+++ b/visibility-filtering/rules/context.rs
@@ -70,6 +70,11 @@ impl ViewerPredicates<'_> {
     }
 
     #[inline]
+    pub fn age_lookup_failed(&self) -> bool {
+        self.ctx.viewer.viewer_age_lookup_failed()
+    }
+
+    #[inline]
     pub fn allows_sensitive_media(&self) -> bool {
         self.ctx.viewer.allows_sensitive_media
     }

--- a/visibility-filtering/rules/golden_corpus.rs
+++ b/visibility-filtering/rules/golden_corpus.rs
@@ -666,6 +666,14 @@ fn age_gating_cases() -> Vec<Case> {
             expected_action: Allow,
             expected_decided_by: None,
         },
+        Case {
+            name: "gizmoduck_age_lookup_failed_drops_sensitive_media",
+            level: TimelineHome,
+            viewer: viewer_with_age(ViewerAge::LookupFailed),
+            candidate: labeled_media(SafetyLabelType::NSFW_HIGH_RECALL),
+            expected_action: Drop(FilteredReason::ContainNsfwMedia),
+            expected_decided_by: Some("SensitiveViewerUnderageDropRule"),
+        },
     ]
 }
 

--- a/visibility-filtering/rules/tweet_rules.rs
+++ b/visibility-filtering/rules/tweet_rules.rs
@@ -228,7 +228,9 @@ fn sensitive_viewer_logged_out(context: &RuleContext<'_>) -> VfAction {
 }
 
 fn sensitive_viewer_underage(context: &RuleContext<'_>) -> VfAction {
-    if context.viewer().is_underage() && sensitive_base_condition(context) {
+    if (context.viewer().is_underage() || context.viewer().age_lookup_failed())
+        && sensitive_base_condition(context)
+    {
         VfAction::Drop(FilteredReason::ContainNsfwMedia)
     } else {
         VfAction::Allow
@@ -679,6 +681,23 @@ mod tests {
         assert_allows(no_age, &gating_viewer(ViewerAge::Unknown), &hp);
         assert_allows(underage, &gating_viewer(ViewerAge::Unknown), &text);
         assert_allows(no_age, &gating_viewer(ViewerAge::Unknown), &text);
+
+        for firing in sensitive_firing_candidates() {
+            assert_drops(
+                underage,
+                &gating_viewer(ViewerAge::LookupFailed),
+                &firing,
+                &reason,
+            );
+        }
+        assert_allows(no_age, &gating_viewer(ViewerAge::LookupFailed), &hp);
+        let us_failed = ViewerFeatures {
+            country_code: Some("us".into()),
+            ..gating_viewer(ViewerAge::LookupFailed)
+        };
+        assert_drops(underage, &us_failed, &text, &reason);
+        let clean = candidate().build();
+        assert_allows(underage, &gating_viewer(ViewerAge::LookupFailed), &clean);
 
         let opted_in = ViewerFeatures {
             allows_sensitive_media: true,


### PR DESCRIPTION
## Bug

Gizmoduck viewer RPC `Err` / timeout was collapsed to `ViewerAge::Unknown`. `SensitiveViewerUnderageDropRule` only matches `Known(age) < 18`. `SensitiveViewerNoStatedAgeDropRule` only matches `NotStated` in a gating country. `Unknown` Allows.

#133 left this: "RPC error already fails open as Unknown." Age-0 is now `NotStated`. A failed read of a real logged-in viewer is not "no such user."

This is not #133 (age 0 sentinel). This is not #125 (mixer origin NSFW). This is not #149 (VF author Failed → omit). This is not #144 (user-label miss).

## Five-line proof

- Entry: `ViewerHydrator::hydrate` (`Err` / timeout used to stamp `Unknown`)
- Sink: `SensitiveViewerUnderageDropRule` (`LookupFailed` now hard-drops sensitive media)
- Break: gizmoduck viewer RPC error assembled as un-aged, so NSFW/gore/card-image never age-gated
- Viewer effect: a 15-year-old (or any viewer) whose gizmoduck row timed out still sees NSFW as a normal For You / Following card
- Twin: confirmed `Unknown` (no such user) and `NotStated` (jurisdiction-scoped) are unchanged. #149 owns author Failed.

## Change

Stamp `ViewerAge::LookupFailed` on gizmoduck viewer `Err` / timeout. The underage drop also fires on `age_lookup_failed` so sensitive media hard-drops globally, including outside `NSFW_GATING_COUNTRIES`. Non-sensitive posts still serve.

## Tests

- Viewer RPC error / timeout → `LookupFailed` (not `Unknown`, not underage, not `NotStated`)
- `LookupFailed` drops every sensitive firing candidate, including NSFW_TEXT in US
- `LookupFailed` allows a clean non-sensitive post
- `Unknown` still Allows (confirmed no-such-user)
- Golden corpus `gizmoduck_age_lookup_failed_drops_sensitive_media`

Standalone decision-table harness (same match arms): 15/15 passed.

`cargo test` cannot run. Public dump has no visibility-filtering crate manifest.

## Leftover

Author gizmoduck Failed is #149. Interstitial on an ancillary quote/RT is #143/#146. Account-country geo is #113.

Fork PR: none