### PR TITLE
Stop age-gating from requiring media on gore-and-violence labels

### DIFF
--- a/visibility-filtering/rules/golden_corpus.rs
+++ b/visibility-filtering/rules/golden_corpus.rs
@@ -666,6 +666,30 @@ fn age_gating_cases() -> Vec<Case> {
             expected_action: Allow,
             expected_decided_by: None,
         },
+        Case {
+            name: "underage_viewer_drops_gore_without_media",
+            level: TimelineHome,
+            viewer: viewer_with_age(ViewerAge::Known(15)),
+            candidate: labeled(SafetyLabelType::GORE_AND_VIOLENCE_HIGH_PRECISION),
+            expected_action: Drop(FilteredReason::ContainNsfwMedia),
+            expected_decided_by: Some("SensitiveViewerUnderageDropRule"),
+        },
+        Case {
+            name: "logged_out_viewer_drops_gore_without_media",
+            level: TimelineHome,
+            viewer: logged_out_viewer(),
+            candidate: labeled(SafetyLabelType::GORE_AND_VIOLENCE_HIGH_PRECISION),
+            expected_action: Drop(FilteredReason::ContainNsfwMedia),
+            expected_decided_by: Some("SensitiveViewerLoggedOutDropRule"),
+        },
+        Case {
+            name: "no_stated_age_in_gating_country_drops_gore_without_media",
+            level: TimelineHome,
+            viewer: no_stated_age_viewer("gb"),
+            candidate: labeled(SafetyLabelType::GORE_AND_VIOLENCE_HIGH_PRECISION),
+            expected_action: Drop(FilteredReason::ContainNsfwMedia),
+            expected_decided_by: Some("SensitiveViewerNoStatedAgeDropRule"),
+        },
     ]
 }
 

--- a/visibility-filtering/rules/tweet_rules.rs
+++ b/visibility-filtering/rules/tweet_rules.rs
@@ -210,7 +210,8 @@ fn nsfw_no_media_label_condition(context: &RuleContext<'_>) -> bool {
     let tweet = context.tweet();
     !context.viewer().is_author()
         && (tweet.has_safety_label(SafetyLabelType::NSFW_TEXT)
-            || tweet.has_safety_label(SafetyLabelType::NSFW_CARD_IMAGE))
+            || tweet.has_safety_label(SafetyLabelType::NSFW_CARD_IMAGE)
+            || tweet.has_safety_label(SafetyLabelType::GORE_AND_VIOLENCE_HIGH_PRECISION))
 }
 
 fn sensitive_base_condition(context: &RuleContext<'_>) -> bool {
@@ -629,6 +630,7 @@ mod tests {
             media_label(SafetyLabelType::GORE_AND_VIOLENCE_HIGH_PRECISION),
             no_media_label(SafetyLabelType::NSFW_TEXT),
             no_media_label(SafetyLabelType::NSFW_CARD_IMAGE),
+            no_media_label(SafetyLabelType::GORE_AND_VIOLENCE_HIGH_PRECISION),
             nsfw_author_media(),
             admin_author,
             nsfw_tweet_flag_media(),
@@ -701,6 +703,24 @@ mod tests {
             ..gating_viewer(ViewerAge::Unknown)
         };
         assert_allows(logged_out, &logged_out_viewer, &hp_no_media);
+
+        let gore_no_media = no_media_label(SafetyLabelType::GORE_AND_VIOLENCE_HIGH_PRECISION);
+        assert_drops(
+            underage,
+            &gating_viewer(ViewerAge::Known(15)),
+            &gore_no_media,
+            &reason,
+        );
+        assert_drops(logged_out, &logged_out_viewer, &gore_no_media, &reason);
+        assert_drops(
+            no_age,
+            &gating_viewer(ViewerAge::NotStated),
+            &gore_no_media,
+            &reason,
+        );
+        let mut gore_self = gore_no_media.clone();
+        gore_self.author_id = VIEWER_ID;
+        assert_allows(underage, &gating_viewer(ViewerAge::Known(15)), &gore_self);
         assert_allows(logged_out, &gating_viewer(ViewerAge::Known(15)), &hp);
 
         let mut no_flags = nsfw_tweet_flag_media();


### PR DESCRIPTION
## Bug

`GoreAndViolenceInterstitialRule` already fires without `has_media()`. Golden corpus case `gore_and_violence_label_interstitials_in_network` pins that with `labeled(GORE_AND_VIOLENCE_HIGH_PRECISION)` (no media).

`SensitiveViewerUnderageDropRule`, `SensitiveViewerLoggedOutDropRule`, and `SensitiveViewerNoStatedAgeDropRule` only treat gore as sensitive through `graphic_base_condition`, which requires media. `NSFW_TEXT` and `NSFW_CARD_IMAGE` already have a no-media branch. Gore was left out.

Policy order runs the age drops before the interstitial. When the drop misses, the interstitial wins. A 15-year-old or logged-out viewer gets a tap-through blur on a gore-labeled card/text post. The same viewers are hard-dropped for `NSFW_CARD_IMAGE` without media.

This is not #133 (gizmoduck age 0). This is not #159 (viewer-age lookup fail-open). This is not #134 (TES media read fail-closed). This is the rule predicate.

## Five-line proof

- Entry: `nsfw_no_media_label_condition` / `graphic_base_condition` in `visibility-filtering/rules/tweet_rules.rs`
- Sink: `SENSITIVE_VIEWER_DROPS` on TimelineHome and TimelineHomeRecommendations (`TIMELINE_HOME_SHARED_RULES`)
- Break: gore + `!has_media()` skipped the drop, then `GoreAndViolenceInterstitialRule` served Interstitial
- Viewer effect: underage / logged-out / no-stated-age-in-gating-country can dismiss a gore interstitial instead of a hard drop
- Twin: `NSFW_TEXT` and `NSFW_CARD_IMAGE` already drop without media; adult interstitial on gore without media is unchanged

## Fix

Add `GORE_AND_VIOLENCE_HIGH_PRECISION` to `nsfw_no_media_label_condition`. Author self-view stays exempt. `NSFW_HIGH_PRECISION` without media stays Allow (`hp_no_media`).

## Tests

- `sensitive_firing_candidates` includes gore without media
- Underage, logged-out, and no-stated-age drop gore without media
- Author self-view still Allows
- Golden corpus: `underage_viewer_drops_gore_without_media`, `logged_out_viewer_drops_gore_without_media`, `no_stated_age_in_gating_country_drops_gore_without_media`
- Adult interstitial case `gore_and_violence_label_interstitials_in_network` unchanged

Standalone decision-table harness (same predicates): 12/12 passed.

`cargo test` cannot run. Public dump has no visibility-filtering crate manifest.

## Leftover

`NSFW_HIGH_PRECISION` without media still Allows underage (`hp_no_media`). Ancillary Interstitial on quote/RT/ancestor remains #143 / #146. TES media read fail-closed remains #134.

Fork PR: none