### PR TITLE
Stop user-cred from counting reverse linked-account edges

### DIFF
--- a/user-cred-v2/UserCredV2App.scala
+++ b/user-cred-v2/UserCredV2App.scala
@@ -104,7 +104,18 @@ object UserCredV2App extends Logging {
       .readMostRecentSnapshotNoOlderThan(AccountExpansionInvestigationsScalaDataset, Days(7))
       .withRemoteReadPolicy(ExplicitLocation(ProcAtla))
       .toTypedPipe
-      .map(row => (row.userId, row.linkedUserId))
+      .flatMap(row => undirectedLinkedPairs(row.userId, row.linkedUserId))
+  }
+
+  // Investigations stores an undirected linked-account pair. Joining only
+  // (userId, linkedUserId) drops main→alt and keeps alt→main — the PageRank
+  // boosting direction (mass flows follower→followee / engager→author).
+  private[user_cred_v2] def undirectedLinkedPairs(
+    userId: Long,
+    linkedUserId: Long,
+  ): Seq[(Long, Long)] = {
+    if (userId == linkedUserId) Seq.empty
+    else Seq((userId, linkedUserId), (linkedUserId, userId))
   }
 
   private[user_cred_v2] def filterLinkedUserEdges(


### PR DESCRIPTION
## Bug

`filterLinkedUserEdges` exists to keep linked-account pairs out of UserCred PageRank. It joined follow and engagement edges on the exact ordered pair `(userId, linkedUserId)` from `AccountExpansionInvestigations`.

That dataset is an undirected investigation pair, not a graph edge. Flock follows and 7-day fav/RT edges are oriented the other way: follower→followee, engager→author. Mass flows that same direction.

## Proof

1. Investigations row is `(mainId, altId)`.
2. Alt follows / likes / RTs main → edge `(altId, mainId)`.
3. Join key `(altId, mainId)` ≠ `(mainId, altId)` → edge kept.
4. PageRank pushes mass follower→followee, so alts pump the primary.
5. Published score feeds `isHighPageRankV2` / `cred.score`. Abuse enforcement skips on `cred.is_high || cred.score >= 50`. Safety-label user-agg excludes high page-rank users from NSFW account labels.

Main→alt was the only direction dropped — the one that does not inflate the primary.

## Fix

Emit both orders of each linked pair (skip self-pairs). `filterLinkedUserEdges` is unchanged. If the snapshot already stores both directions, the extra keys are a no-op.

One file: `user-cred-v2/UserCredV2App.scala`.

Not a home-mixer / VF / Thunder change. Not a fork PR.