### PR TITLE
scarecrow: write NSFW_CARD_IMAGE URL verdicts from Grok media_update

### DIFF
--- a/botmaker-rules/scarecrow/bot/NSFW_Grok_Generated_Image_To_URL_Verdict.bot
+++ b/botmaker-rules/scarecrow/bot/NSFW_Grok_Generated_Image_To_URL_Verdict.bot
@@ -25,6 +25,21 @@ action: |
         OneDayInSecs * 75
       );
     }
+    # grok_share (24603) is the only other writer and requires this label
+    # already to exist. When the share mapping is populated here, that
+    # event has already fired without the label and will not fire again.
+    # Write the URL verdict from the share ids this bot already fetched,
+    # matching 7429 (card image) and 24603 (share event).
+    for (:shareId in :grok_share_ids) {
+      val :url = Concat("https://x.com/i/grok/share/", Trim(ToString(:shareId)));
+      val :urlVerdict = GetUrlVerdictV2(:url);
+      val :verdict = DictGetOrElse(:urlVerdict, "verdict", "UNKNOWN");
+      if (:verdict != "NSFW_CARD_IMAGE" && :verdict != "BAD") {
+        WriteUrlVerdictsV2(Set(:url), "NSFW_CARD_IMAGE", 86400 * 7, "EXACT_URL_MATCH","updating reputation store for NSFW detection","botmaker", "bot_24493");
+        IncrementStat("Grok_URLs_added_as_NSFW_CARD_IMAGE_in_Rep_Store", 1);
+        Log("nsfw_card_url_grok_media_update_log", :url);
+      }
+    }
   }
 expiry: '2029-10-18T21:18:09.279Z'
 isActive: 'true'


### PR DESCRIPTION
## Problem

Bot 24493 (`NSFW_Grok_Generated_Image_To_URL_Verdict`) scores Grok-generated images on `media_update` and is the only bot that looks up existing Grok share ids. It never writes a URL verdict.

The only writer is bot 24603 (`NSFW_Grok_Share`). That bot runs on `grok_share` and requires `GrokMediaNsfwDetection` to already exist. When the share mapping is populated at `media_update` time, `grok_share` has already fired without the label and will not fire again.

No `NSFW_CARD_IMAGE` PUT is written. Bot 7413 therefore never applies tweet interstitials to posts that embed `https://x.com/i/grok/share/{id}`. Card-image bot 7429 writes the verdict directly from `media_update`; the Grok path does not.

## Proof

1. 24493 fetches `:grok_share_ids = GetGrokShareIdsFromGrokMediaId(entityId)` and only logs them.
2. 24493 `SetLabelWithTtl("GrokMediaNsfwDetection", …)` and returns. There is no `WriteUrlVerdictsV2`.
3. 24603's condition is `GetLabel("GrokMediaNsfwDetection", …) != ""` on `grok_share`.
4. A non-empty share mapping at media_update means the share event already happened, so 24603 already no-op'd.
5. 7413 only reacts to `url_reputation_change` PUT of `NSFW_CARD_IMAGE`. That PUT never occurs.

## Change

After setting the media label, write `NSFW_CARD_IMAGE` for each already-mapped share URL, matching 7429 and 24603 (7-day TTL, skip if the verdict is already `NSFW_CARD_IMAGE` or `BAD`). The media label is unchanged, so the score-then-share path still works.

## Tests

These bots run inside Botmaker against internal Strato. There is no in-repo harness. Correctness is the event-order split plus the write that 24493 already had the inputs for.

| Event order | Share ids at 24493 | Before | After |
|---|---|---|---|
| score, then share | empty | 24603 writes | 24603 writes |
| share, then score | non-empty | nobody writes | 24493 writes |
| already labeled | non-empty | nobody writes | 24493 no-ops (`NSFW_CARD_IMAGE` / `BAD`) |

Not a sibling of #104 (7429 DELETE cleanup) or #107 (`GetTweetLabelInfoFromURL` RTF-read fail-open). Different bots, different event, missing write rather than unreachable delete.

Fork PR: none