### PR TITLE
media-model-proxy: fail closed when every NSFW replica drops scores

### DIFF
--- a/media-model-proxy/src/main/scala/com/twitter/media_understanding/model_proxy/services/ModelsService.scala
+++ b/media-model-proxy/src/main/scala/com/twitter/media_understanding/model_proxy/services/ModelsService.scala
@@ -84,10 +84,22 @@ class ModelsService(
 
         Future
           .collectToTry(result)
-          .map { responses: Seq[Try[PredictionResponse]] =>
-            responses
+          .flatMap { responses: Seq[Try[PredictionResponse]] =>
+            val successes = responses
               .filter { response => filterException(response, model) }
               .map { predictionResponseTry => predictionResponseTry.get().prediction }
+
+            // Attempted replicas that all fail must not become a successful empty
+            // score list: callers persist that as unlabeled / SFW.
+            if (result.nonEmpty && successes.isEmpty) {
+              val cause = responses
+                .collectFirst { case Throw(ex) => ex }
+                .getOrElse(new IllegalStateException(s"${model.name} produced no scores"))
+              stats.scope(model.name).counter("fail_closed").incr()
+              Future.exception(cause)
+            } else {
+              Future.value(successes)
+            }
           }
     }
   }

--- a/media-model-proxy/src/test/scala/com/twitter/media_understanding/model_proxy/services/ModelsServiceSpec.scala
+++ b/media-model-proxy/src/test/scala/com/twitter/media_understanding/model_proxy/services/ModelsServiceSpec.scala
@@ -4,6 +4,7 @@ import com.twitter.cortex_media_annotator.thriftscala.MediaModel
 import com.twitter.finagle.NoBrokersAvailableException
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.media_understanding.model_proxy.clients.ModelClient
+import com.twitter.media_understanding.model_proxy.exception.GreyScaleImageException
 import com.twitter.media_understanding.model_proxy.model_descriptors.ModelDescriptor
 import com.twitter.media_understanding.model_proxy.model_descriptors.ModelDescriptorRegistry
 import com.twitter.mediaservices.commons.thriftscala.MediaCategory
@@ -88,7 +89,7 @@ class ModelsServiceSpec extends FunSuite with MockitoSugar with BeforeAndAfterEa
   }
 
   test(
-    "getPrediction returns empty list of response if all models in cluster throw PredictionException"
+    "getPrediction fails closed if all models in cluster throw PredictionException"
   ) {
     when(client_1.isAvailable)
       .thenReturn(true)
@@ -100,12 +101,13 @@ class ModelsServiceSpec extends FunSuite with MockitoSugar with BeforeAndAfterEa
     when(client_2.predictFromModel(mockAny[PredictionRequest]))
       .thenReturn(Future.exception(new PredictionServiceException("")))
 
-    val result = Await.result(deepBirdService.getPrediction(Some(mediaCategory), model, media))
-    assert(result.isEmpty)
+    intercept[PredictionServiceException] {
+      Await.result(deepBirdService.getPrediction(Some(mediaCategory), model, media))
+    }
   }
 
   test(
-    "getPrediction returns empty list of response if all models in cluster throw non fatal exceptions"
+    "getPrediction fails closed if all models in cluster throw non fatal exceptions"
   ) {
     when(client_1.isAvailable)
       .thenReturn(true)
@@ -117,8 +119,27 @@ class ModelsServiceSpec extends FunSuite with MockitoSugar with BeforeAndAfterEa
     when(client_2.predictFromModel(mockAny[PredictionRequest]))
       .thenReturn(Future.exception(new IllegalArgumentException()))
 
-    val result = Await.result(deepBirdService.getPrediction(Some(mediaCategory), model, media))
-    assert(result.isEmpty)
+    intercept[IllegalArgumentException] {
+      Await.result(deepBirdService.getPrediction(Some(mediaCategory), model, media))
+    }
+  }
+
+  test(
+    "getPrediction fails closed with GreyScaleImageException when every replica hits a greyscale decode error"
+  ) {
+    val grey = new PredictionServiceException(deepBirdService.greyScaleErrorString)
+    when(client_1.isAvailable)
+      .thenReturn(true)
+    when(client_2.isAvailable)
+      .thenReturn(true)
+    when(client_1.predictFromModel(mockAny[PredictionRequest]))
+      .thenReturn(Future.exception(grey))
+    when(client_2.predictFromModel(mockAny[PredictionRequest]))
+      .thenReturn(Future.exception(grey))
+
+    intercept[GreyScaleImageException] {
+      Await.result(deepBirdService.getPrediction(Some(mediaCategory), model, media))
+    }
   }
 
   test(
@@ -155,6 +176,8 @@ class ModelsServiceSpec extends FunSuite with MockitoSugar with BeforeAndAfterEa
     when(client_2.isAvailable)
       .thenReturn(false)
 
+    // Kill-switched / filtered-out replicas were never attempted, so empty is
+    // not a swallowed error.
     val result2 = Await.result(deepBirdService.getPrediction(Some(mediaCategory), model, media))
     assert(result2.isEmpty)
   }


### PR DESCRIPTION
## Summary

Media Model Proxy is the production path that scores tweet images, videos, and GIFs for `XX_NSFW` (and the other media-understanding models) before Media Analysis persists the result. When every Deepbird replica errors, `getPrediction` currently **succeeds with an empty score list**. Callers treat that as unlabeled / SFW, so adult media ranks and ships as safe whenever xx-nsfw is down, times out, or rejects the bytes (including greyscale).

This is not a Scala-parity leftover and is not in the claimed VF / Grok / Thunder / DNA / ads / Phoenix lanes.

## Five-line proof

1. `ModelsService.getPrediction` uses `Future.collectToTry` and `filterException` to drop every `NonFatal` replica error, including `PredictionServiceException` and `GreyScaleImageException`.
2. The existing tests encoded the fail-open: all replicas throw → `assert(result.isEmpty)`.
3. `ProxyController` then builds `AnnotationResponse(..., annotations = Some(predictions.toMap))` and increments **success**. An empty `Seq[DataRecord]` is a successful `XxNsfw` key.
4. README: MMP does not persist scores; Media Analysis interprets and stores whatever comes back. Missing `nsfw.default.score` is "not NSFW."
5. Greyscale is the dead-code tell: the proxy already rewrites the color-model error into `GreyScaleImageException(BadRequest, MediaNotSupported)`, then `filterException` swallows it so the client never sees the BadRequest.

Partial replica failure still returns the surviving scores. Kill-switched models (no replica attempted) still return empty.

## Fix

If any replica was attempted and zero valid scores remain, fail the Future with the first error (`fail_closed` counter). Greyscale decode errors now surface as `GreyScaleImageException` instead of a successful empty map.

## Tests

- All-cluster `PredictionServiceException` and other `NonFatal` errors now `intercept` instead of accepting empty.
- New coverage: greyscale decode error on every replica fails closed with `GreyScaleImageException`.
- Existing partial-failure and disabled-client tests unchanged.

Scala/Bazel is not available in this environment, so `ModelsServiceSpec` was not executed here.