### PR TITLE
Stop For You topic snooze from dropping untagged posts

### DIFF
--- a/home-mixer/filters/topic_ids_filter.rs
+++ b/home-mixer/filters/topic_ids_filter.rs
@@ -90,12 +90,14 @@ impl Filter<ScoredPostsQuery, PostCandidate> for TopicIdsFilter {
             let mut excluded_expanded = TopicIdExpansion::expand(&excluded_ids);
             excluded_expanded.extend(&excluded_ids);
 
+            // Snooze is exclusion-only. Missing or empty topic hydration is
+            // not a match -- same safe harbor as bulk Explore unlabeled filler.
             let (new_kept, new_removed): (Vec<_>, Vec<_>) =
                 kept.into_iter().partition(|c| match &c.filtered_topic_ids {
                     Some(candidate_topics) if !candidate_topics.is_empty() => !candidate_topics
                         .iter()
                         .any(|tid| excluded_expanded.contains(tid)),
-                    _ => false,
+                    _ => true,
                 });
             kept = new_kept;
             removed.extend(new_removed);
@@ -1103,8 +1105,49 @@ mod tests {
         let result = TopicIdsFilter.filter(&query, candidates);
         let kept_ids: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
         let removed_ids: Vec<u64> = result.removed.iter().map(|c| c.tweet_id).collect();
-        assert_eq!(kept_ids, vec![2]);
-        assert_eq!(removed_ids, vec![1, 3, 4]);
+        assert_eq!(kept_ids, vec![2, 3, 4]);
+        assert_eq!(removed_ids, vec![1]);
+    }
+
+    #[test]
+    fn test_excluded_topics_keeps_untagged_and_hydration_miss() {
+        let query = ScoredPostsQuery {
+            excluded_topic_ids: vec![TopicIdExpansion::XAI_SPORTS_REAL],
+            ..Default::default()
+        };
+
+        let candidates = vec![
+            PostCandidate {
+                tweet_id: 1,
+                filtered_topic_ids: None,
+                ..Default::default()
+            },
+            PostCandidate {
+                tweet_id: 2,
+                filtered_topic_ids: Some(vec![]),
+                ..Default::default()
+            },
+            PostCandidate {
+                tweet_id: 3,
+                filtered_topic_ids: Some(vec![TopicIdExpansion::XAI_SPORTS_REAL]),
+                ..Default::default()
+            },
+            PostCandidate {
+                tweet_id: 4,
+                filtered_topic_ids: Some(vec![TopicIdExpansion::XAI_AI]),
+                ..Default::default()
+            },
+        ];
+
+        let result = TopicIdsFilter.filter(&query, candidates);
+        let kept_ids: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
+        let removed_ids: Vec<u64> = result.removed.iter().map(|c| c.tweet_id).collect();
+        assert_eq!(
+            kept_ids,
+            vec![1, 2, 4],
+            "hydration miss and known-untagged stay on For You snooze"
+        );
+        assert_eq!(removed_ids, vec![3]);
     }
 
     #[test]
@@ -1244,8 +1287,8 @@ mod tests {
 
         let result = TopicIdsFilter.filter(&query, candidates);
         let kept_ids: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
-        assert_eq!(kept_ids, vec![3]);
-        assert_eq!(result.removed.len(), 3);
+        assert_eq!(kept_ids, vec![3, 4]);
+        assert_eq!(result.removed.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Bug

For You with snoozed topics (`excluded_topic_ids`, surface `for_you_with_snoozed_topics`) runs `TopicIdsFilter` after `FilteredTopicsHydrator`. The excluded branch keeps a post only when `filtered_topic_ids` is a non-empty list with no snoozed id. `None` (Strato miss) and `Some([])` (known untagged) both take `_ => false` and are removed.

Snoozing Sports (or any one topic) therefore deletes every lawful post that is not already tagged with some other surviving topic. Personal tweets, replies, and anything Strato did not label disappear. This is a successful filter result on the wrong set, not ranking weight.

This is not Explore topic hydration miss (bulk `topic_ids` fail-closed on `None`). That path is inclusion/exclusion of withheld Explore inventory. This path is For You snooze treating unlabeled speech as a positive exclude match.

## Proof

- Entry: `ScoredPostsQuery.excluded_topic_ids` on For You snooze
- Sink: `TopicIdsFilter` excluded partition (Phoenix pre-score)
- Break: `None` and `Some([])` take `_ => false`
- Viewer effect: one snoozed topic drops all untagged For You posts
- Twin: bulk Explore unlabeled filler keeps `None` / empty (`_ => true`)

## Fix

Keep missing and empty topic lists on the excluded branch. A snoozed topic still drops a post that actually carries that id (or an expanded child). Untagged posts stay.

## Tests

- Overwrite: snooze Sports keeps the AI post, the hydration miss, and the known-empty list; only the Sports-tagged post is removed.
- Overwrite: multiple excluded topics still drop matching tagged posts and now keep the untagged sibling.
- Keep: any-match (Sports+Politics), Entertainment group expansion, mixed inclusion+exclusion, News+disasters expansion.
- New: hydration miss and known-untagged stay on For You snooze; Sports-tagged still drops.