### PR TITLE
Stop communityNoteVisible from requiring NMR-to-CRH

### DIFF
--- a/botmaker/scarecrow_features/src/main/java/com/twitter/scarecrow/features/FeaturesOfBirdwatchStatusChangeEvent.java
+++ b/botmaker/scarecrow_features/src/main/java/com/twitter/scarecrow/features/FeaturesOfBirdwatchStatusChangeEvent.java
@@ -17,28 +17,39 @@ public class FeaturesOfBirdwatchStatusChangeEvent extends FeatureMapExtractor {
 
   @Override
   public void apply(FeatureMapBuilder builder) throws Exception {
-    if (event.isSetTweetId()) {
-      if (event.isSetBeforeStatus() && event.isSetAfterStatus()) {
-        builder.putValue(FeatureModifier.REQUIRED, BotMakerFeatures.tweetId, event.getTweetId());
-        boolean isPreviouslyNMR = event.getBeforeStatus()
-            == BirdwatchNoteRatingStatus.NEEDS_MORE_RATINGS;
-        boolean isCurrentlyCRH = event.getAfterStatus()
-            == BirdwatchNoteRatingStatus.CURRENTLY_RATED_HELPFUL;
-        builder.putValue(FeatureModifier.REQUIRED, BotMakerFeatures.communityNoteVisible,
-            isPreviouslyNMR && isCurrentlyCRH);
-      } else if (event.isSetNoteStatusChanges() && event.getNoteStatusChangesSize() > 0) {
-        builder.putValue(FeatureModifier.REQUIRED, BotMakerFeatures.tweetId, event.getTweetId());
-        boolean featureValue = false;
-        for (BirdwatchStatusChangeEventNoteStatusChange change : event.getNoteStatusChanges()) {
-          if (change.isSetBeforeStatus() && change.isSetAfterStatus()
-              && change.getBeforeStatus() == BirdwatchNoteRatingStatus.NEEDS_MORE_RATINGS
-              && change.getAfterStatus() == BirdwatchNoteRatingStatus.CURRENTLY_RATED_HELPFUL) {
-            featureValue = true;
-          }
+    if (!event.isSetTweetId()) {
+      return;
+    }
+
+    boolean hasStatus = false;
+    boolean visible = false;
+
+    if (event.isSetAfterStatus()) {
+      hasStatus = true;
+      visible = isCurrentlyRatedHelpful(event.getAfterStatus());
+    }
+
+    if (event.isSetNoteStatusChanges()) {
+      for (BirdwatchStatusChangeEventNoteStatusChange change : event.getNoteStatusChanges()) {
+        if (!change.isSetAfterStatus()) {
+          continue;
         }
-        builder.putValue(FeatureModifier.REQUIRED, BotMakerFeatures.communityNoteVisible,
-            featureValue);
+        hasStatus = true;
+        if (isCurrentlyRatedHelpful(change.getAfterStatus())) {
+          visible = true;
+        }
       }
     }
+
+    if (!hasStatus) {
+      return;
+    }
+
+    builder.putValue(FeatureModifier.REQUIRED, BotMakerFeatures.tweetId, event.getTweetId());
+    builder.putValue(FeatureModifier.REQUIRED, BotMakerFeatures.communityNoteVisible, visible);
+  }
+
+  private static boolean isCurrentlyRatedHelpful(BirdwatchNoteRatingStatus status) {
+    return status == BirdwatchNoteRatingStatus.CURRENTLY_RATED_HELPFUL;
   }
 }


### PR DESCRIPTION
## Bug
`communityNoteVisible` is the write bit that applies `NSFA_COMMUNITY_NOTE`. That label is MediumRisk in ads brand safety. Default For You blending then treats MediumRisk as avoid and parks the post in filler after ad slots.

The bit was true only on NEEDS_MORE_RATINGS to CURRENTLY_RATED_HELPFUL. A note that flipped from CURRENTLY_RATED_NOT_HELPFUL to CURRENTLY_RATED_HELPFUL, or that stayed CURRENTLY_RATED_HELPFUL while another note changed, reported not visible. Tweet-level before/after also hid per-note CURRENTLY_RATED_HELPFUL: if both fields were set, note-level changes were ignored.

High-reach misinfo with a shown note then kept ranked safe slots. A later non-NMR event on a still-shown note reported false and could drop the label while the note was still on the post.

## Fix
Set `communityNoteVisible` from after-status. True when the tweet-level after-status is CURRENTLY_RATED_HELPFUL, or when any per-note after-status is. Tweet-level and note-level are unioned. Before-status is not used.

No change to label TTL, GetSafetyLabels, VF drop rules, or ads verdict math.

## Proof
- Entry: `FeaturesOfBirdwatchStatusChangeEvent.apply` writes `communityNoteVisible`
- Sink: `NSFA_COMMUNITY_NOTE` -> `compute_verdict` MediumRisk -> `has_avoid` -> `partition_organic` filler
- Break: required NMR-to-CRH; tweet-level before/after skipped per-note CRH
- Viewer effect: shown note on a high-reach post left it in ranked safe slots
- Twin: `NSFA_COMMUNITY_NOTE` is already MediumRisk next to `DO_NOT_AMPLIFY` / `GROK_NSFA`

## Tests
Birdwatch thrift is not in this dump, so the extractor cannot be compiled here. Decision table on unmodified vs fixed logic:

- NMR -> CRH: true / true
- CRNH -> CRH: false / true
- CRH -> CRH: false / true
- CRH -> CRNH, no other CRH note: false / false
- tweet-level CRH plus a note NMR -> CRH: false / true
- tweet-level CRNH plus a note after CRH: false / true
- no after-status: emit nothing / emit nothing
