### PR TITLE
Stop safemodel R/X scores from applying hard-NSFW drop labels

### DIFF
--- a/grox/flows/ptos/safemodel_enforce.py
+++ b/grox/flows/ptos/safemodel_enforce.py
@@ -1,0 +1,13 @@
+"""Safemodel sex-and-nudity scores are comparison-only.
+
+The classifier returns MPAA-style R/X buckets. R is not a policy hit.
+NsfwHighRecall / NsfwHighPrecision drops are OON For You kills and must
+come from a PTOS AdultContentSexualHard decision, not from safemodel
+alone.
+"""
+
+
+def should_apply_safemodel_nsfw_drop_labels(
+    safemodel_positive: bool, ptos_confirmed_hard_nsfw: bool
+) -> bool:
+    return bool(safemodel_positive and ptos_confirmed_hard_nsfw)

--- a/grox/flows/ptos/task_write_safety_post_annotations_result_sink.py
+++ b/grox/flows/ptos/task_write_safety_post_annotations_result_sink.py
@@ -5,6 +5,9 @@ import time
 from grox.core.tasks.task import Task
 from grox.flows.ptos.constants import HIGH_FAV_THRESHOLD
 from grox.flows.ptos.disable_rules import DisableTaskForNonPtosProd
+from grox.flows.ptos.safemodel_enforce import (
+    should_apply_safemodel_nsfw_drop_labels,
+)
 from monitor.metrics import Metrics
 from grox.core.schedules.types import TaskContext
 from grox.flows.ptos.state import SafetyPtosState
@@ -16,7 +19,6 @@ from strato_http.queries.data_types import (
     SafetyPostAnnotationsResult,
     SafetyBoolMetadata,
     SafetyPtosViolatedPolicy,
-    SafetyPolicy,
     SafetyPolicyCategory,
     SafetyPolicyType,
     FoundMetadata,
@@ -404,58 +406,21 @@ class TaskWriteSafetyPostAnnotationsResultSink(Task):
 
         ptos_already_nsfw = new_bool_metadata.isNsfw
         safemodel = ctx.state(SafetyPtosState).safemodel_sex_nudity
-        if safemodel.positive and not ptos_already_nsfw:
-            safemodel_confidence_int = round(safemodel.confidence * 100)
-            safemodel_annotation = SafetyPostAnnotations(
-                tweetId=post_id,
-                violatedPolicies=[
-                    SafetyPtosViolatedPolicy(
-                        category=SafetyPolicyCategory.AdultContent,
-                        score=safemodel_confidence_int,
-                        reason="safemodel sex-and-nudity classifier detected adult content",
-                        safetyPolicy=SafetyPolicy(
-                            policyType=SafetyPolicyType.AdultContentSexualHard,
-                            confidenceScore=safemodel_confidence_int,
-                            reason="safemodel sex-and-nudity classifier detected adult content",
-                        ),
-                    ),
-                ],
-                foundMetadata=found_metadata,
-                identifier="safemodel-sex-nudity",
-                timestamp=timestamp_ms,
-            )
-            annotations_list.append(safemodel_annotation)
-            merged_bool_metadata = cls._merge_bool_metadata(
-                merged_bool_metadata,
-                SafetyBoolMetadata(
-                    isGore=False, isNsfw=True, isSoftNsfw=False, isSpam=False
-                ),
-            )
-
+        if safemodel.positive and not should_apply_safemodel_nsfw_drop_labels(
+            safemodel_positive=True,
+            ptos_confirmed_hard_nsfw=ptos_already_nsfw,
+        ):
+            # Safemodel returns R/X media buckets. The compare task already
+            # records safemodel_only_positive. Minting AdultContentSexualHard
+            # here applied NsfwHighRecall/NsfwHighPrecision and dropped OON
+            # For You for news, art, protest, and other non-violating speech.
             Metrics.counter(
-                "task.write_safety_post_annotations_result_sink.safemodel_enforced.count"
+                "task.write_safety_post_annotations_result_sink.safemodel_shadow.count"
             ).add(1)
-            safemodel_applied_labels = await cls._apply_labels_for_annotation(
-                safemodel_annotation, post=post
+            logger.info(
+                f"safemodel sex-nudity positive without PTOS AdultContentSexualHard "
+                f"for post {post_id}; not applying NSFW drop labels"
             )
-            if len(safemodel_applied_labels) > 0:
-                logger.info(
-                    f"safemodel enforce: applyLabelFromPtos applied labels {safemodel_applied_labels} for post {post_id}"
-                )
-                Metrics.counter(
-                    "task.write_safety_post_annotations_result_sink.safemodel_action.count"
-                ).add(1)
-                for label in safemodel_applied_labels:
-                    Metrics.counter(
-                        "task.write_safety_post_annotations_result_sink.safemodel_action.applied_label.count"
-                    ).add(1, attributes={"label": label})
-            else:
-                logger.info(
-                    f"safemodel enforce: applyLabelFromPtos applied no labels for post {post_id}"
-                )
-                Metrics.counter(
-                    "task.write_safety_post_annotations_result_sink.safemodel_action.empty.count"
-                ).add(1)
 
         final_result = SafetyPostAnnotationsResult(
             tweetId=post_id,

--- a/grox/flows/ptos/test_safemodel_enforce.py
+++ b/grox/flows/ptos/test_safemodel_enforce.py
@@ -1,0 +1,39 @@
+import unittest
+
+from grox.flows.ptos.safemodel_enforce import (
+    should_apply_safemodel_nsfw_drop_labels,
+)
+
+
+class SafemodelEnforceTest(unittest.TestCase):
+    def test_safemodel_only_positive_does_not_apply_drop_labels(self):
+        self.assertFalse(
+            should_apply_safemodel_nsfw_drop_labels(
+                safemodel_positive=True, ptos_confirmed_hard_nsfw=False
+            )
+        )
+
+    def test_ptos_hard_nsfw_already_labeled_does_not_need_safemodel(self):
+        self.assertTrue(
+            should_apply_safemodel_nsfw_drop_labels(
+                safemodel_positive=True, ptos_confirmed_hard_nsfw=True
+            )
+        )
+
+    def test_neither_positive_does_not_apply_drop_labels(self):
+        self.assertFalse(
+            should_apply_safemodel_nsfw_drop_labels(
+                safemodel_positive=False, ptos_confirmed_hard_nsfw=False
+            )
+        )
+
+    def test_ptos_only_does_not_mint_labels_from_safemodel(self):
+        self.assertFalse(
+            should_apply_safemodel_nsfw_drop_labels(
+                safemodel_positive=False, ptos_confirmed_hard_nsfw=True
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The PTOS write sink treated safemodel sex-and-nudity R/X scores as AdultContentSexualHard when the policy model found no hard-NSFW hit.

Safemodel is a high-recall media classifier (`R` is not a policy violation). Deluxe runs it on every media post. The sink then applied NsfwHighRecall and NsfwHighPrecision, which VF drops on TimelineHomeRecommendations. News, art, protest, and other non-violating speech lost OON For You reach.

PTOS AdultContentSexualHard still applies those labels. Comparison metrics stay.

## Proof

- Entry: grox PlanSafetyPtos task_safety_ptos_safemodel_sex_nudity (R/X buckets; deluxe has no adult-suspicion gate)
- Sink: TaskWriteSafetyPostAnnotationsResultSink then VF NsfwHighRecallDropRule / NsfwHighPrecisionOonDropRule
- Break: `if safemodel.positive and not ptos_already_nsfw` minted SexualHard and applied drop labels
- Viewer effect: non-violating OON post disappears from For You; followers still see it on TimelineHome
- Twin: safemodel compare outcome `safemodel_only_positive` is shadow, not enforce

## Tests

- test_safemodel_only_positive_does_not_apply_drop_labels
- test_ptos_hard_nsfw_already_labeled_does_not_need_safemodel
- python3 -m unittest grox.flows.ptos.test_safemodel_enforce
