### PR TITLE
Stop UserCred teleport from weighting likes by yesterday's mass

### DIFF
--- a/user-cred-v2/UserCredV2App.scala
+++ b/user-cred-v2/UserCredV2App.scala
@@ -141,7 +141,6 @@ object UserCredV2App extends Logging {
   private[user_cred_v2] def computeTeleportWeights(
     validUserInfoPipe: TypedPipe[ValidUserInfo],
     engagementPipe: TypedPipe[Edge],
-    priorMassPipe: TypedPipe[UserMass],
     beta: Double,
   ): TypedPipe[UserMass] = {
     val engagementCounts = engagementPipe
@@ -154,14 +153,18 @@ object UserCredV2App extends Logging {
       .group
       .sum
 
+    // Exogenous like/RT share: each current valid engager contributes equally.
+    // Joining yesterday's PageRank mass here made cred the input to cred.
+    val validEngagerIds = validUserInfoPipe.map(u => (u.id, ())).group
+
     val rawEngagementWeights = engagementCounts
       .map { case ((engagerId, destinationId), count) => (engagerId, (destinationId, count)) }
       .group
       .join(totalCountsPerEngager)
-      .join(priorMassPipe.groupBy(_.id))
+      .join(validEngagerIds)
       .map {
-        case (_, (((destinationId, count), totalCount), engagerMass)) =>
-          (destinationId, engagerMass.mass * count.toDouble / totalCount.toDouble)
+        case (_, (((destinationId, count), totalCount), _)) =>
+          (destinationId, count.toDouble / totalCount.toDouble)
       }
       .group
       .sum
@@ -222,7 +225,6 @@ object UserCredV2App extends Logging {
     val teleportWeightsPipe = computeTeleportWeights(
       validUserInfoPipe,
       engagementPipe,
-      priorMassPipe,
       config.engagementTeleportBeta
     )
     val userNodePipe = getPageRankGraph(validUserInfoPipe, edgePipe)


### PR DESCRIPTION
## Bug

`computeTeleportWeights` built today's engagement teleport by inner-joining 7-day fav/RT edges onto yesterday's UserCred mass. An engager with no prior snapshot row contributed nothing. An engager with high prior mass donated that mass to every author they liked.

That is cred as an input to cred. Small and new accounts cannot confer authority. Elite like-rings reprint yesterday's ranking into today's teleport, then PageRank publishes tomorrow's prior.

Not the linked-pair filter. Not the premium uniform prior. Warm-start still reads the previous snapshot as the PageRank start vector only.

## Proof

1. Entry: `computeTeleportWeights` joined `(engagerId, authorId)` fav/RT counts onto `priorMassPipe` (previous UserCred snapshot, or uniform only on `first_snapshot`).
2. Sink: `engagerMass.mass * count / total` became today's teleport. `doPageRank` plus `writeResults` wrote tomorrow's `priorMassPipe`. New engagers died on the inner join.
3. Break: drop the prior-mass join. Each current valid engager donates `count / total` only. Invalid / deactivated rows no longer mint cred from leftover mass.
4. Viewer effect: published `UserCredV2.score` / `isHighPageRankV2` stop following last week's elite like-graph. Abuse skips and embedding `user_credibility` stop treating small-account endorsements as zero.
5. Twin: same 7-day fav/RT graph, yesterday's masses swapped vs uniform. Old code moves teleport with the masses. New code does not.

## Fix

One function: `user-cred-v2/UserCredV2App.scala` `computeTeleportWeights`. Call site drops the unused prior-mass argument.

Not a home-mixer / VF / Thunder change. Not a fork PR.