### PR TITLE
Recompute mutual-follow bits on cached For You posts

### DIFF
--- a/home-mixer/candidate_hydrators/bidirectional_follow_hydrator.rs
+++ b/home-mixer/candidate_hydrators/bidirectional_follow_hydrator.rs
@@ -14,7 +14,7 @@ pub struct BidirectionalFollowHydrator {
 #[async_trait]
 impl Hydrator<ScoredPostsQuery, PostCandidate> for BidirectionalFollowHydrator {
     fn enable(&self, query: &ScoredPostsQuery) -> bool {
-        query.params.get(EnableBidirectionalFollowHydration) && !query.has_cached_posts
+        query.params.get(EnableBidirectionalFollowHydration)
     }
 
     async fn hydrate(
@@ -205,11 +205,70 @@ mod tests {
     }
 
     #[test]
-    fn disabled_for_cached_posts() {
+    fn enabled_on_cache_hit_and_miss() {
         let hydrator = hydrator(vec![]);
         let mut q = query(vec![1], true);
         assert!(hydrator.enable(&q));
         q.has_cached_posts = true;
-        assert!(!hydrator.enable(&q));
+        assert!(hydrator.enable(&q));
+    }
+
+    fn apply_update(
+        hydrator: &BidirectionalFollowHydrator,
+        candidate: &mut PostCandidate,
+        hydrated: PostCandidate,
+    ) {
+        hydrator.update(candidate, hydrated);
+    }
+
+    #[tokio::test]
+    async fn cache_hit_clears_stale_mutual_when_author_unfollowed_viewer() {
+        let hydrator = hydrator(vec![]);
+        let mut q = query(vec![2], true);
+        q.has_cached_posts = true;
+        let mut cached = PostCandidate {
+            author_id: 2,
+            is_mutual_follow_author: Some(true),
+            ..Default::default()
+        };
+
+        let out = hydrator.hydrate(&q, &[cached.clone()]).await;
+        apply_update(&hydrator, &mut cached, out[0].as_ref().unwrap().clone());
+
+        assert_eq!(cached.is_mutual_follow_author, Some(false));
+    }
+
+    #[tokio::test]
+    async fn cache_hit_clears_stale_mutual_when_viewer_unfollowed() {
+        let hydrator = hydrator(vec![2]);
+        let mut q = query(vec![], true);
+        q.has_cached_posts = true;
+        let mut cached = PostCandidate {
+            author_id: 2,
+            is_mutual_follow_author: Some(true),
+            ..Default::default()
+        };
+
+        let out = hydrator.hydrate(&q, &[cached.clone()]).await;
+        apply_update(&hydrator, &mut cached, out[0].as_ref().unwrap().clone());
+
+        assert_eq!(cached.is_mutual_follow_author, Some(false));
+    }
+
+    #[tokio::test]
+    async fn cache_hit_sets_newly_mutual_follow_bit() {
+        let hydrator = hydrator(vec![2]);
+        let mut q = query(vec![2], true);
+        q.has_cached_posts = true;
+        let mut cached = PostCandidate {
+            author_id: 2,
+            is_mutual_follow_author: Some(false),
+            ..Default::default()
+        };
+
+        let out = hydrator.hydrate(&q, &[cached.clone()]).await;
+        apply_update(&hydrator, &mut cached, out[0].as_ref().unwrap().clone());
+
+        assert_eq!(cached.is_mutual_follow_author, Some(true));
     }
 }


### PR DESCRIPTION
## Bug

`BidirectionalFollowHydrator.enable` was `flag && !has_cached_posts`.

`FollowedUserIdsQueryHydrator` still runs on a cache hit. The follow list is current. `RankingScorer` still runs. It reads `is_mutual_follow_author` and, when that bit is `Some(true)`, adds `BidirectionalFollowReplyWeightBoost` to the reply head. That boost defaults to 15.0 on a `ReplyWeight` of 5.0.

Skipping the hydrator keeps the bit written up to 180s earlier. A new mutual does not get the boost. A broken mutual keeps a 4x reply-head weight. `PhoenixScorer` is also skipped on the cache hit, so the weighted score is rebuilt from cached phoenix heads times the stale bit.

`CachedPostsQueryHydrator` sets `has_cached_posts` when Redis returns at least 500 posts. TTL is 180s.

This is not #135 (`in_network` bit). Not #156 (block / nsfw_author / quote).

## Five-line proof

- Entry: `BidirectionalFollowHydrator` (`enable` skipped `has_cached_posts`)
- Sink: `RankingScorer::reply_weight_for` / `dwell_weight_for` (`is_mutual_follow_author == Some(true)`)
- Break: cache hit left the Redis slate bit in place while the follow list was live
- Viewer effect: originals from a new mutual stay unboosted; originals from a broken mutual keep a 4x reply-head boost for up to 180s
- Twin: #135 recomputes `in_network` on the same cache hit; #156 recomputes block / nsfw bits

## Fix

Enable whenever the hydration flag is on. `update` overwrites the cached bits.

## Tests

- `enable` is true on cache hit and miss
- cache-hit hydrate + update: author no longer follows viewer -> `Some(false)`
- cache-hit hydrate + update: viewer unfollowed -> `Some(false)`
- cache-hit hydrate + update: newly mutual -> `Some(true)`

`RankingScorer` test `bidirectional_weight_boosts_only_mutual_original_posts` is the score sink.

`cargo test` cannot run here. Public dump has no Home Mixer manifest.
