### PR TITLE
Rescore cached For You posts when the action sequence is newer

### DIFF
--- a/home-mixer/scorers/phoenix_scorer.rs
+++ b/home-mixer/scorers/phoenix_scorer.rs
@@ -58,19 +58,54 @@ impl PhoenixScorer {
 
         configured_cluster
     }
+
+    fn ranker_killed(query: &ScoredPostsQuery) -> bool {
+        query
+            .decider
+            .as_ref()
+            .is_some_and(|d| d.enabled(PHOENIX_RANKER_KILL_SWITCH_DECIDER))
+    }
+
+    /// Latest viewer-action time from the already-hydrated scoring sequence.
+    /// `last_modified_epoch_ms` is when UAS last wrote; `last_sequence_time`
+    /// is the newest action in the window. Either being newer than a frozen
+    /// Phoenix head means For You is ranking on stale predictions.
+    fn scoring_sequence_fresh_ms(query: &ScoredPostsQuery) -> Option<u64> {
+        let meta = query.scoring_sequence.as_ref()?.metadata.as_ref()?;
+        let ts = meta.last_modified_epoch_ms.max(meta.last_sequence_time);
+        (ts > 0).then_some(ts)
+    }
+
+    fn cached_phoenix_scores_are_stale(query: &ScoredPostsQuery) -> bool {
+        let Some(sequence_ms) = Self::scoring_sequence_fresh_ms(query) else {
+            return false;
+        };
+        query.cached_posts.iter().any(|candidate| {
+            candidate
+                .last_scored_at_ms
+                .is_none_or(|scored_at| scored_at < sequence_ms)
+        })
+    }
+
+    /// Cache hits still hydrate a fresh UAS sequence. Skip Phoenix only when
+    /// every cached head was scored at or after that sequence; otherwise the
+    /// 180s Redis slate keeps VQV / dwell / fav predictions from before the
+    /// viewer finished or skipped videos.
+    fn should_score(query: &ScoredPostsQuery) -> bool {
+        if Self::ranker_killed(query) {
+            return false;
+        }
+        if !query.has_cached_posts {
+            return true;
+        }
+        query.scoring_sequence.is_some() && Self::cached_phoenix_scores_are_stale(query)
+    }
 }
 
 #[async_trait]
 impl Scorer<ScoredPostsQuery, PostCandidate> for PhoenixScorer {
     fn enable(&self, query: &ScoredPostsQuery) -> bool {
-        if query.has_cached_posts {
-            return false;
-        }
-        let killed = query
-            .decider
-            .as_ref()
-            .is_some_and(|d| d.enabled(PHOENIX_RANKER_KILL_SWITCH_DECIDER));
-        !killed
+        Self::should_score(query)
     }
 
     async fn score(
@@ -127,5 +162,101 @@ impl Scorer<ScoredPostsQuery, PostCandidate> for PhoenixScorer {
         candidate.prediction_request_id = scored.prediction_request_id;
         candidate.last_scored_at_ms = scored.last_scored_at_ms;
         candidate.reranker_head_tag = scored.reranker_head_tag;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_recsys_proto::{UserActionSequence, UserActionSequenceMeta};
+
+    fn sequence(last_modified_epoch_ms: u64, last_sequence_time: u64) -> UserActionSequence {
+        UserActionSequence {
+            metadata: Some(UserActionSequenceMeta {
+                last_modified_epoch_ms,
+                last_sequence_time,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn cached_query(
+        last_scored_at_ms: Option<u64>,
+        seq: Option<UserActionSequence>,
+    ) -> ScoredPostsQuery {
+        ScoredPostsQuery {
+            has_cached_posts: true,
+            cached_posts: vec![PostCandidate {
+                tweet_id: 1,
+                last_scored_at_ms,
+                ..Default::default()
+            }],
+            scoring_sequence: seq,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn scores_uncached_requests() {
+        assert!(PhoenixScorer::should_score(&ScoredPostsQuery::default()));
+    }
+
+    #[test]
+    fn keeps_cache_when_sequence_is_older_than_heads() {
+        let query = cached_query(Some(2_000), Some(sequence(1_500, 1_400)));
+        assert!(!PhoenixScorer::should_score(&query));
+    }
+
+    #[test]
+    fn rescores_cache_when_sequence_is_newer_than_heads() {
+        let query = cached_query(Some(1_000), Some(sequence(2_500, 2_400)));
+        assert!(PhoenixScorer::should_score(&query));
+    }
+
+    #[test]
+    fn rescores_cache_when_only_last_sequence_time_is_newer() {
+        let query = cached_query(Some(1_000), Some(sequence(0, 1_001)));
+        assert!(PhoenixScorer::should_score(&query));
+    }
+
+    #[test]
+    fn rescores_cache_when_cached_head_has_no_score_time() {
+        let query = cached_query(None, Some(sequence(2_000, 2_000)));
+        assert!(PhoenixScorer::should_score(&query));
+    }
+
+    #[test]
+    fn keeps_cache_when_sequence_has_no_usable_time() {
+        let query = cached_query(Some(1_000), Some(sequence(0, 0)));
+        assert!(!PhoenixScorer::should_score(&query));
+    }
+
+    #[test]
+    fn keeps_cache_when_sequence_is_missing() {
+        let query = cached_query(Some(1_000), None);
+        assert!(!PhoenixScorer::should_score(&query));
+    }
+
+    #[test]
+    fn rescores_when_any_cached_head_is_older_than_the_sequence() {
+        let query = ScoredPostsQuery {
+            has_cached_posts: true,
+            cached_posts: vec![
+                PostCandidate {
+                    tweet_id: 1,
+                    last_scored_at_ms: Some(3_000),
+                    ..Default::default()
+                },
+                PostCandidate {
+                    tweet_id: 2,
+                    last_scored_at_ms: Some(1_000),
+                    ..Default::default()
+                },
+            ],
+            scoring_sequence: Some(sequence(2_000, 2_000)),
+            ..Default::default()
+        };
+        assert!(PhoenixScorer::should_score(&query));
     }
 }


### PR DESCRIPTION
Cache hits still hydrate a fresh UAS scoring sequence, then PhoenixScorer disabled itself whenever has_cached_posts was set. RankingScorer kept blending the Redis-frozen Phoenix heads (VQV, dwell, fav) for the full 180s TTL, so For You order ignored videos the viewer just finished or skipped.

Proof
- Entry: ScoringSequenceQueryHydrator writes query.scoring_sequence on every request, including cache hits.
- Sink: PhoenixScorer.enable / RankingScorer.compute_weighted_parts (vqv_score, dwell, fav) into For You score.
- Break: enable() returned false on has_cached_posts, so last_scored_at_ms heads older than metadata.last_modified_epoch_ms / last_sequence_time never refreshed.
- Viewer: after a VQV or skip, pull-to-refresh still ranks the same cached slate as if those actions never happened.
- Twin: metadata.length already gates new-user cluster selection in this same scorer; cache skip is the only path that ignores a newer sequence.

Fix: keep the Redis candidate cache, but run Phoenix again when any cached last_scored_at_ms is missing or older than the hydrated sequence. Unchanged cache hits stay skipped. Missing sequence stays skipped so update() cannot wipe cached heads with Default scores.