### PR TITLE
Stop ancillary VF from dropping followee quotes of civic-labeled posts

### DIFF
--- a/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
+++ b/home-mixer/candidate_hydrators/vf_candidate_hydrator.rs
@@ -9,7 +9,7 @@ use tonic::async_trait;
 use xai_candidate_pipeline::hydrator::Hydrator;
 use xai_twittercontext_proto::GetTwitterContextViewer;
 use xai_twittercontext_proto::TwitterContextViewer;
-use xai_visibility_filtering::models::{Action, FilteredReason};
+use xai_visibility_filtering::models::{Action, FilteredReason, SafetyResultReason};
 use xai_visibility_filtering::vf_client::SafetyLevel;
 use xai_visibility_filtering::vf_client::SafetyLevel::{TimelineHome, TimelineHomeRecommendations};
 use xai_visibility_filtering::vf_client::{TweetVisibility, VfClient};
@@ -146,12 +146,18 @@ pub(crate) fn should_drop_ancillary(
     candidate: &PostCandidate,
     vf_results: &HashMap<u64, Result<Option<FilteredReason>>>,
 ) -> bool {
+    // Quotes and replies are the attached author's speech. Civic integrity
+    // is a do-not-amplify label on the attached post, not a policy drop on
+    // the commentary. In-network cards keep that commentary. Retweets are
+    // amplification of the labeled post and still drop.
+    let skip_civic = candidate.in_network == Some(true);
+
     for &ancestor_id in &candidate.ancestors {
         if candidate.tombstone_ancestor_ids.contains(&ancestor_id) {
             continue;
         }
         if let Some(Ok(Some(reason))) = vf_results.get(&ancestor_id)
-            && should_drop_reason(reason)
+            && should_drop_reason(reason, skip_civic)
         {
             return true;
         }
@@ -159,14 +165,14 @@ pub(crate) fn should_drop_ancillary(
 
     if let Some(quoted_id) = candidate.quoted_tweet_id
         && let Some(Ok(Some(reason))) = vf_results.get(&quoted_id)
-        && should_drop_reason(reason)
+        && should_drop_reason(reason, skip_civic)
     {
         return true;
     }
 
     if let Some(retweeted_id) = candidate.retweeted_tweet_id
         && let Some(Ok(Some(reason))) = vf_results.get(&retweeted_id)
-        && should_drop_reason(reason)
+        && should_drop_reason(reason, false)
     {
         return true;
     }
@@ -174,11 +180,114 @@ pub(crate) fn should_drop_ancillary(
     false
 }
 
-fn should_drop_reason(reason: &FilteredReason) -> bool {
+fn is_civic_integrity_drop(reason: &FilteredReason) -> bool {
+    matches!(
+        reason,
+        FilteredReason::SafetyResult(safety_result)
+            if safety_result.reason == Some(SafetyResultReason::FosnrCivicIntegrity)
+                && matches!(safety_result.action, Action::Drop(_))
+    )
+}
+
+fn should_drop_reason(reason: &FilteredReason, skip_civic: bool) -> bool {
+    if skip_civic && is_civic_integrity_drop(reason) {
+        return false;
+    }
     match reason {
         FilteredReason::SafetyResult(safety_result) => {
             matches!(safety_result.action, Action::Drop(_))
         }
-        _ => true, 
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_visibility_filtering::models::SafetyResult;
+
+    fn civic_drop() -> FilteredReason {
+        FilteredReason::SafetyResult(SafetyResult {
+            reason: Some(SafetyResultReason::FosnrCivicIntegrity),
+            action: Action::Drop(Default::default()),
+        })
+    }
+
+    fn dna_drop() -> FilteredReason {
+        FilteredReason::PossiblyUndesirable
+    }
+
+    fn results(id: u64, reason: FilteredReason) -> HashMap<u64, Result<Option<FilteredReason>>> {
+        HashMap::from([(id, Ok(Some(reason)))])
+    }
+
+    #[test]
+    fn in_network_quote_of_civic_is_kept() {
+        let quote = PostCandidate {
+            tweet_id: 1,
+            in_network: Some(true),
+            quoted_tweet_id: Some(99),
+            ..Default::default()
+        };
+        assert!(!should_drop_ancillary(&quote, &results(99, civic_drop())));
+    }
+
+    #[test]
+    fn in_network_reply_with_civic_ancestor_is_kept() {
+        let reply = PostCandidate {
+            tweet_id: 2,
+            in_network: Some(true),
+            in_reply_to_tweet_id: Some(88),
+            ancestors: vec![88],
+            ..Default::default()
+        };
+        assert!(!should_drop_ancillary(&reply, &results(88, civic_drop())));
+    }
+
+    #[test]
+    fn oon_quote_of_civic_is_dropped() {
+        let quote = PostCandidate {
+            tweet_id: 3,
+            in_network: Some(false),
+            quoted_tweet_id: Some(99),
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(&quote, &results(99, civic_drop())));
+    }
+
+    #[test]
+    fn in_network_retweet_of_civic_is_dropped() {
+        let retweet = PostCandidate {
+            tweet_id: 4,
+            in_network: Some(true),
+            retweeted_tweet_id: Some(77),
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(
+            &retweet,
+            &results(77, civic_drop())
+        ));
+    }
+
+    #[test]
+    fn in_network_quote_of_do_not_amplify_is_still_dropped() {
+        let quote = PostCandidate {
+            tweet_id: 5,
+            in_network: Some(true),
+            quoted_tweet_id: Some(99),
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(&quote, &results(99, dna_drop())));
+    }
+
+    #[test]
+    fn missing_in_network_quote_of_civic_is_dropped() {
+        let quote = PostCandidate {
+            tweet_id: 6,
+            in_network: None,
+            quoted_tweet_id: Some(99),
+            ..Default::default()
+        };
+        assert!(should_drop_ancillary(&quote, &results(99, civic_drop())));
     }
 }

--- a/visibility-filtering/rules/golden_corpus.rs
+++ b/visibility-filtering/rules/golden_corpus.rs
@@ -192,6 +192,13 @@ fn nsfw_high_precision_reason() -> FilteredReason {
     })
 }
 
+fn civic_integrity_reason() -> FilteredReason {
+    FilteredReason::SafetyResult(SafetyResult {
+        reason: Some(SafetyResultReason::FosnrCivicIntegrity),
+        action: Action::Drop(DropReason {}),
+    })
+}
+
 fn filter_all_cases() -> Vec<Case> {
     vec![
         Case {
@@ -504,7 +511,7 @@ fn tweet_label_cases() -> Vec<Case> {
             level: TimelineHome,
             viewer: viewer(VIEWER_ID),
             candidate: labeled(SafetyLabelType::FOSNR_CIVIC_INTEGRITY),
-            expected_action: Drop(FilteredReason::PossiblyUndesirable),
+            expected_action: Drop(civic_integrity_reason()),
             expected_decided_by: Some("FosnrCivicIntegrityDropRule"),
         },
     ]
@@ -894,6 +901,14 @@ fn oon_tweet_label_cases() -> Vec<Case> {
             candidate: labeled(SafetyLabelType::DO_NOT_AMPLIFY),
             expected_action: Drop(FilteredReason::PossiblyUndesirable),
             expected_decided_by: Some("DoNotAmplifyOonDropRule"),
+        },
+        Case {
+            name: "fosnr_civic_integrity_label_drops_oon",
+            level: TimelineHomeRecommendations,
+            viewer: viewer(VIEWER_ID),
+            candidate: labeled(SafetyLabelType::FOSNR_CIVIC_INTEGRITY),
+            expected_action: Drop(civic_integrity_reason()),
+            expected_decided_by: Some("FosnrCivicIntegrityDropRule"),
         },
         Case {
             name: "malicious_url_label_drops_oon",

--- a/visibility-filtering/rules/tweet_rules.rs
+++ b/visibility-filtering/rules/tweet_rules.rs
@@ -10,6 +10,11 @@ const NSFW_HIGH_PRECISION_REASON: FilteredReason = FilteredReason::SafetyResult(
     action: Action::Drop(DropReason {}),
 });
 
+const CIVIC_INTEGRITY_REASON: FilteredReason = FilteredReason::SafetyResult(SafetyResult {
+    reason: Some(SafetyResultReason::FosnrCivicIntegrity),
+    action: Action::Drop(DropReason {}),
+});
+
 pub(super) const TWEET_LABEL_DROPS: &[RuleSpec] = &[
     RuleSpec::Tweet {
         name: "PdnaTweetLabelRule",
@@ -56,7 +61,7 @@ pub(super) const TWEET_LABEL_DROPS: &[RuleSpec] = &[
     RuleSpec::Tweet {
         name: "FosnrCivicIntegrityDropRule",
         when: |tweet| tweet.has_safety_label(SafetyLabelType::FOSNR_CIVIC_INTEGRITY),
-        action: RuleAction::Drop(FilteredReason::PossiblyUndesirable),
+        action: RuleAction::Drop(CIVIC_INTEGRITY_REASON),
         exempt_author: true,
     },
 ];


### PR DESCRIPTION
## Bug

For You fetches quoted posts and conversation ancestors at TimelineHomeRecommendations. `should_drop_ancillary` treats any Recs Drop on those ids as a drop of the card.

`FosnrCivicIntegrityDropRule` is in the shared Home table, so Recs Drops civic-labeled posts. A followee quote or reply then dies in `AncillaryVFFilter` even when the followee's own post has no civic label.

Civic integrity is a do-not-amplify mark on the attached post. A quote or reply is the followee's speech. Hate / abuse / violent-speech ancillary drops are unchanged. DoNotAmplify tweet-label drops on quotes are unchanged.

This is not the civic Home-table move. This is not retweet source-label hydration. This is not Following quotes scored at Home.

## Fix

Emit civic drops as `SafetyResult` / `FosnrCivicIntegrity` so the mixer can tell them apart from generic `PossiblyUndesirable` (spam, DNA, abuse-insults).

In-network quotes and ancestor replies skip that civic Drop. Out-of-network quotes still drop. Retweets of a civic-labeled original still drop.

The labeled civic post itself still Drops on Home and Recs.

## Proof

- Entry: `VFCandidateHydrator` puts `quoted_tweet_id` and `ancestors` on TimelineHomeRecommendations
- Sink: `should_drop_ancillary` -> `AncillaryVFFilter`
- Break: civic Recs Drop on the attached id removed the followee card
- Viewer effect: followed quote or reply of a civic-labeled post vanishes from For You
- Twin: `DoNotAmplifyOonDropRule` still drops a quote of a DNA-labeled post

## Tests

- In-network quote of civic: keep
- In-network reply with civic ancestor: keep
- OON quote of civic: drop
- In-network retweet of civic: drop
- In-network quote of DoNotAmplify: still drop
- Missing `in_network` on a civic quote: drop
- Golden: civic still Drops on Home and Recs via `FosnrCivicIntegrityDropRule`

`cargo test` cannot run. Public dump has no Home Mixer or VF crate manifest. Mixer match logic was compiled and run as a rustc model: 6/6 passed.
