### PR TITLE
Stop seen/served filters from dropping replies to seen parents

### DIFF
--- a/home-mixer/filters/previously_seen_posts_backup_filter.rs
+++ b/home-mixer/filters/previously_seen_posts_backup_filter.rs
@@ -78,6 +78,23 @@ mod tests {
     }
 
     #[test]
+    fn test_keeps_reply_when_only_parent_was_impressed() {
+        let query = ScoredPostsQuery {
+            impressed_post_ids: vec![10],
+            ..Default::default()
+        };
+        let reply = PostCandidate {
+            tweet_id: 20,
+            in_reply_to_tweet_id: Some(10),
+            ..Default::default()
+        };
+        let result = PreviouslySeenPostsBackupFilter.filter(&query, vec![reply, make_candidate(10)]);
+        let kept: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
+        let removed: Vec<u64> = result.removed.iter().map(|c| c.tweet_id).collect();
+        assert_eq!(kept, vec![20]);
+        assert_eq!(removed, vec![10]);
+    }
+
     fn test_empty_candidates() {
         let query = ScoredPostsQuery {
             impressed_post_ids: vec![1, 2],

--- a/home-mixer/filters/previously_seen_posts_filter.rs
+++ b/home-mixer/filters/previously_seen_posts_filter.rs
@@ -33,3 +33,48 @@ impl Filter<ScoredPostsQuery, PostCandidate> for PreviouslySeenPostsFilter {
         FilterResult { kept, removed }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(tweet_id: u64, retweeted: Option<u64>, in_reply_to: Option<u64>) -> PostCandidate {
+        PostCandidate {
+            tweet_id,
+            retweeted_tweet_id: retweeted,
+            in_reply_to_tweet_id: in_reply_to,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn keeps_reply_when_only_the_parent_was_seen() {
+        let query = ScoredPostsQuery {
+            seen_ids: vec![10],
+            ..Default::default()
+        };
+        let result = PreviouslySeenPostsFilter.filter(
+            &query,
+            vec![
+                candidate(20, None, Some(10)),
+                candidate(10, None, None),
+                candidate(30, Some(10), None),
+            ],
+        );
+        let kept: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
+        let removed: Vec<u64> = result.removed.iter().map(|c| c.tweet_id).collect();
+        assert_eq!(kept, vec![20]);
+        assert_eq!(removed, vec![10, 30]);
+    }
+
+    #[test]
+    fn drops_reply_when_the_reply_itself_was_seen() {
+        let query = ScoredPostsQuery {
+            seen_ids: vec![20],
+            ..Default::default()
+        };
+        let result = PreviouslySeenPostsFilter.filter(&query, vec![candidate(20, None, Some(10))]);
+        assert!(result.kept.is_empty());
+        assert_eq!(result.removed.len(), 1);
+    }
+}

--- a/home-mixer/filters/previously_served_posts_filter.rs
+++ b/home-mixer/filters/previously_served_posts_filter.rs
@@ -32,3 +32,34 @@ impl Filter<ScoredPostsQuery, PostCandidate> for PreviouslyServedPostsFilter {
         FilterResult { kept, removed }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_reply_when_only_the_parent_was_served() {
+        let query = ScoredPostsQuery {
+            served_ids: vec![10],
+            ..Default::default()
+        };
+        let result = PreviouslyServedPostsFilter.filter(
+            &query,
+            vec![
+                PostCandidate {
+                    tweet_id: 20,
+                    in_reply_to_tweet_id: Some(10),
+                    ..Default::default()
+                },
+                PostCandidate {
+                    tweet_id: 10,
+                    ..Default::default()
+                },
+            ],
+        );
+        let kept: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
+        let removed: Vec<u64> = result.removed.iter().map(|c| c.tweet_id).collect();
+        assert_eq!(kept, vec![20]);
+        assert_eq!(removed, vec![10]);
+    }
+}

--- a/home-mixer/util/candidates_util.rs
+++ b/home-mixer/util/candidates_util.rs
@@ -4,16 +4,11 @@ use crate::models::query::ScoredPostsQuery;
 const MAX_FOLLOWERS_THRESHOLD: i64 = 10_000;
 
 pub fn get_related_post_ids(candidate: &PostCandidate) -> Vec<u64> {
-    let mut ids = vec![candidate.tweet_id];
-    ids.extend(candidate.retweeted_tweet_id);
-    ids.extend(candidate.in_reply_to_tweet_id);
-    ids
+    related_post_ids_iter(candidate).collect()
 }
 
 pub fn related_post_ids_iter(candidate: &PostCandidate) -> impl Iterator<Item = u64> {
-    std::iter::once(candidate.tweet_id)
-        .chain(candidate.retweeted_tweet_id)
-        .chain(candidate.in_reply_to_tweet_id)
+    std::iter::once(candidate.tweet_id).chain(candidate.retweeted_tweet_id)
 }
 
 pub fn vqv_weight(
@@ -62,6 +57,27 @@ pub fn quoted_vqv_weight(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn candidate(tweet_id: u64, retweeted: Option<u64>, in_reply_to: Option<u64>) -> PostCandidate {
+        PostCandidate {
+            tweet_id,
+            retweeted_tweet_id: retweeted,
+            in_reply_to_tweet_id: in_reply_to,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn related_ids_are_the_card_and_retweet_original_only() {
+        let reply = candidate(20, None, Some(10));
+        assert_eq!(get_related_post_ids(&reply), vec![20]);
+
+        let retweet = candidate(30, Some(10), None);
+        assert_eq!(get_related_post_ids(&retweet), vec![30, 10]);
+
+        let original = candidate(10, None, None);
+        assert_eq!(get_related_post_ids(&original), vec![10]);
+    }
 
     #[test]
     fn quoted_vqv_returns_weight_when_check_disabled() {


### PR DESCRIPTION
## Bug

`related_post_ids_iter` chained `in_reply_to_tweet_id` next to the candidate id and the retweet original. PreviouslySeen, PreviouslySeenBackup, and PreviouslyServed hard-drop a candidate when any related id is in seen / impressed / served.

A reply is new speech. Seeing or serving the parent is not seeing the reply. Followee replies to a post the viewer already scrolled past never reach For You.

This is not #151 (quote same-card). #151 adds `quoted_tweet_id`. This removes the parent id. A retweet of a seen original still drops.

## Five-line proof

- Entry: TES / Thunder `in_reply_to_tweet_id` on an in-network reply
- Sink: PreviouslySeen / PreviouslySeenBackup / PreviouslyServed (`related_post_ids_iter`)
- Break: parent id was treated as the reply card
- Viewer effect: a followee reply to a seen/served/impressed post disappears from For You
- Twin: same reply kept when the parent is absent from those sets; RT of a seen original still drops

## Fix

Same-card ids are the post and its retweet original only.

## Tests

- related_ids_are_the_card_and_retweet_original_only
- keeps_reply_when_only_the_parent_was_seen
- drops_reply_when_the_reply_itself_was_seen
- keeps_reply_when_only_parent_was_impressed
- keeps_reply_when_only_the_parent_was_served

`cargo test` cannot run. Public dump has no Home Mixer manifest.

Fork PR: none