### PR TITLE
Stop engagement-count store errors from zeroing For You rank features

### DIFF
--- a/home-mixer/candidate_hydrators/engagement_counts_hydrator.rs
+++ b/home-mixer/candidate_hydrators/engagement_counts_hydrator.rs
@@ -131,16 +131,30 @@ impl CachedHydrator<ScoredPostsQuery, PostCandidate> for EngagementCountsHydrato
         unique_ids.sort_unstable();
         unique_ids.dedup();
 
+        // Store errors must not become Ok(empty). CachedHydrator caches Ok, and
+        // as_tweet_info unwrap_or(0) would stamp Phoenix / Thompson as zero
+        // engagement for 60s. LanguageCode / MediaInfo already return Err here.
         let counts = if unique_ids.is_empty() {
-            HashMap::new()
+            Ok(HashMap::new())
         } else {
-            self.client
-                .get_engagement_counts(&unique_ids)
-                .await
-                .unwrap_or_else(|e| {
-                    warn!(error = %e, "engagement_counts_hydration dragonfly_error");
-                    HashMap::new()
-                })
+            self.client.get_engagement_counts(&unique_ids).await
+        };
+
+        let counts = match counts {
+            Ok(counts) => counts,
+            Err(e) => {
+                warn!(error = %e, "engagement_counts_hydration dragonfly_error");
+                return candidates
+                    .iter()
+                    .map(|c| {
+                        if !fetch_counts(c) {
+                            Ok(preserve_counts(c))
+                        } else {
+                            Err(format!("engagement_counts dragonfly_error: {e}"))
+                        }
+                    })
+                    .collect();
+            }
         };
 
         candidates
@@ -326,5 +340,118 @@ mod tests {
         assert_eq!(first[0].as_ref().unwrap().view_count, Some(5));
         assert_eq!(second[0].as_ref().unwrap().view_count, Some(5));
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[derive(Default)]
+    struct FailingClient {
+        calls: AtomicUsize,
+    }
+
+    #[tonic::async_trait]
+    impl EngagementCountsClient for FailingClient {
+        async fn get_engagement_counts(
+            &self,
+            _tweet_ids: &[u64],
+        ) -> Result<HashMap<u64, EngagementCounts>, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err("dragonfly down".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn store_error_returns_err_instead_of_zero_counts() {
+        let h = EngagementCountsHydrator::new(Arc::new(FailingClient::default())).await;
+        let candidates = vec![PostCandidate {
+            tweet_id: 10,
+            author_id: 1,
+            fav_count: Some(99),
+            view_count: Some(50),
+            view_count_on_home: Some(40),
+            ..Default::default()
+        }];
+        let q = query(false, &[(COUNTS, "true")]);
+        let result = h.hydrate_from_client(&q, &candidates).await;
+        assert!(
+            result[0]
+                .as_ref()
+                .err()
+                .is_some_and(|e| e.contains("dragonfly_error")),
+            "store error must not become Ok(zero counts), got {:?}",
+            result[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn store_error_does_not_overwrite_or_cache_zeros() {
+        let client = Arc::new(FailingClient::default());
+        let h = EngagementCountsHydrator::new(client.clone()).await;
+        let candidates = vec![PostCandidate {
+            tweet_id: 10,
+            author_id: 1,
+            fav_count: Some(99),
+            view_count: Some(50),
+            view_count_on_home: Some(40),
+            ..Default::default()
+        }];
+        let q = query(false, &[(COUNTS, "true")]);
+
+        let first = xai_candidate_pipeline::hydrator::Hydrator::hydrate(&h, &q, &candidates).await;
+        let second = xai_candidate_pipeline::hydrator::Hydrator::hydrate(&h, &q, &candidates).await;
+        assert!(first[0].is_err());
+        assert!(second[0].is_err());
+        assert_eq!(
+            client.calls.load(Ordering::SeqCst),
+            2,
+            "Err must not be cached as empty counts"
+        );
+
+        let mut live = candidates;
+        xai_candidate_pipeline::hydrator::Hydrator::update_all(&h, &mut live, first);
+        assert_eq!(live[0].fav_count, Some(99));
+        assert_eq!(live[0].view_count, Some(50));
+        assert_eq!(live[0].view_count_on_home, Some(40));
+    }
+
+    #[tokio::test]
+    async fn store_error_preserves_cached_ineligible_and_errs_eligible() {
+        let h = EngagementCountsHydrator::new(Arc::new(FailingClient::default())).await;
+        let candidates = vec![
+            PostCandidate {
+                tweet_id: 10,
+                author_id: 1,
+                author_followers_count: Some(100),
+                view_count: Some(5),
+                ..Default::default()
+            },
+            PostCandidate {
+                tweet_id: 20,
+                author_id: 2,
+                author_followers_count: Some(5000),
+                view_count: Some(999),
+                ..Default::default()
+            },
+        ];
+        let q = query(
+            true,
+            &[(COLD_START, "true"), (COUNTS, "true"), (CAP, "1000")],
+        );
+        let result = h.hydrate_from_client(&q, &candidates).await;
+        assert!(result[0].is_err());
+        assert_eq!(result[1].as_ref().unwrap().view_count, Some(999));
+    }
+
+    #[tokio::test]
+    async fn successful_miss_still_hydrates_empty_counts() {
+        let h = hydrator(HashMap::new()).await;
+        let candidates = vec![PostCandidate {
+            tweet_id: 10,
+            author_id: 1,
+            fav_count: Some(99),
+            ..Default::default()
+        }];
+        let q = query(false, &[(COUNTS, "true")]);
+        let result = h.hydrate_from_client(&q, &candidates).await;
+        assert_eq!(result[0].as_ref().unwrap().fav_count, None);
+        assert_eq!(result[0].as_ref().unwrap().view_count, None);
     }
 }


### PR DESCRIPTION
Dragonfly Err in EngagementCountsHydrator was coerced to an empty HashMap. Every candidate then got Ok(CachedCounts::default()). CachedHydrator caches Ok for 60s. as_tweet_info unwrap_or(0) stamps Phoenix InputBuffer and Thompson sampling as if the post had no favs, replies, or views.

Proof
- Entry: EngagementCountsHydrator::hydrate_from_client (get_engagement_counts)
- Sink: PostCandidate::as_tweet_info -> Phoenix stamp_engagement_counts; AuthorColdStart Thompson (view_count_on_home, fav_count)
- Break: unwrap_or_else empty map -> Ok(default) -> Moka insert
- Viewer: a viral post ranks like a zero-engagement post for up to 60s after a store blip; the whole slate can collapse together
- Twin: LanguageCodeHydrator and MediaInfoHydrator return Err on store error, so update_all skips and the cache does not store empties

This is not #171/#177 (notes). Not #172 (author diversity retweeter key). Not #173 (safemodel). Not #174 (UserCred). Not #175/#176 (cache mutual-follow / Phoenix rescore). Not #142 (empty Phoenix heads). Not #22 (cold-start thresholds). Not #21 (DPP missing embeddings).

Fix: on client Err, return Err for candidates that need a fetch. CachedHydrator does not insert. update_all leaves existing counts. Successful per-id misses stay Ok(default), same as a tweet with no row.

Tests cover store Err (no zero stamp), no cache poison, cached-post ineligible preserve, and successful miss unchanged.

cargo test cannot run here. Public dump has no Home Mixer manifest. Standalone rustc model of the stamp path passed 4/4.