### PR TITLE
Drop For You posts whose author handle matches a muted keyword

### DIFF
--- a/home-mixer/filters/viewer_muted_keyword_filter.rs
+++ b/home-mixer/filters/viewer_muted_keyword_filter.rs
@@ -43,8 +43,7 @@ impl Filter<ScoredPostsQuery, PostCandidate> for ViewerMutedKeywordFilter {
             let mut removed = Vec::new();
 
             for candidate in candidates {
-                let tweet_text_token_sequence = tokenizer.tokenize(&candidate.tweet_text);
-                if matcher.matches(&tweet_text_token_sequence) {
+                if candidate_matches(&candidate, &tokenizer, &matcher) {
                     removed.push(candidate);
                 } else {
                     kept.push(candidate);
@@ -54,6 +53,17 @@ impl Filter<ScoredPostsQuery, PostCandidate> for ViewerMutedKeywordFilter {
             FilterResult { kept, removed }
         })
     }
+}
+
+fn candidate_matches(
+    candidate: &PostCandidate,
+    tokenizer: &TweetTokenizer,
+    matcher: &MatchTweetGroup,
+) -> bool {
+    std::iter::once(candidate.tweet_text.as_str())
+        .chain(candidate.author_screen_name.as_deref())
+        .filter(|text| !text.is_empty())
+        .any(|text| matcher.matches(&tokenizer.tokenize(text)))
 }
 
 #[cfg(test)]
@@ -314,5 +324,38 @@ mod tests {
         assert_eq!(result.kept.len(), 1);
         assert_eq!(result.kept[0].tweet_id, 4);
         assert_eq!(result.removed.len(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drops_when_author_handle_matches_muted_keyword() {
+        let filter = ViewerMutedKeywordFilter::new();
+        let query = create_test_query(vec!["mutedkeyword".to_string()]);
+
+        let mut handle_only = create_test_candidate(1, "hello");
+        handle_only.author_screen_name = Some("mutedkeyword".to_string());
+
+        let mut other_handle = create_test_candidate(2, "hello");
+        other_handle.author_screen_name = Some("otheruser".to_string());
+
+        let result = filter.filter(&query, vec![handle_only, other_handle]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 2);
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn keeps_when_author_handle_does_not_match() {
+        let filter = ViewerMutedKeywordFilter::new();
+        let query = create_test_query(vec!["mutedkeyword".to_string()]);
+
+        let mut candidate = create_test_candidate(1, "hello");
+        candidate.author_screen_name = Some("otheruser".to_string());
+
+        let result = filter.filter(&query, vec![candidate]);
+
+        assert_eq!(result.kept.len(), 1);
+        assert!(result.removed.is_empty());
     }
 }


### PR DESCRIPTION
## Bug
Gizmoduck already writes `author_screen_name` on For You. `ViewerMutedKeywordFilter` only matched `tweet_text`.

A muted keyword that is the card author's handle never hid the post when the body was clean. `@mutedkeyword` posting `"hello"` still ranked.

This is not quoted-author handle mute-keyword (#140). Not RT original-author handle mute-keyword (#164). Not Phoenix reply-parent VF (#180). Not notes x ranking (#171 / #177).

## Fix
Tokenize the already-hydrated `author_screen_name` with the same mute-keyword matcher as tweet text.

## Proof
- Entry: GizmoduckCandidateHydrator writes `author_screen_name` before ViewerMutedKeywordFilter
- Sink: ViewerMutedKeywordFilter on PhoenixCandidatePipeline
- Break: filter walked `tweet_text` only; card handle was never tokenized
- Viewer effect: @mutedkeyword posts "hello" still serve on For You
- Twin: test_mention_keyword already drops @handle in tweet text; #140 / #164 cover quote and RT handles only

## Tests
- drops_when_author_handle_matches_muted_keyword
- keeps_when_author_handle_does_not_match
- unit tests added; cargo test cannot run in the public dump (no home-mixer Cargo.toml)
