### PR TITLE
Stop OON reply filter from dropping followee Phoenix replies

### DIFF
--- a/home-mixer/filters/oon_retweet_reply_filter.rs
+++ b/home-mixer/filters/oon_retweet_reply_filter.rs
@@ -13,8 +13,8 @@ impl Filter<ScoredPostsQuery, PostCandidate> for OONRetweetReplyFilter {
         let (removed, kept): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|c| {
             let is_reply = c.in_reply_to_tweet_id.is_some();
             let is_retweet = c.retweeted_tweet_id.is_some();
-            (c.in_network == Some(false) && (is_retweet || is_reply))
-                || (is_reply && c.ancestors.is_empty())
+            // Empty ancestors is a Phoenix producer gap, not an OON signal.
+            c.in_network == Some(false) && (is_retweet || is_reply)
         });
 
         FilterResult { kept, removed }
@@ -43,7 +43,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drops_oon_retweets_replies_and_replies_missing_ancestors() {
+    async fn drops_oon_retweets_and_replies_only() {
         let filter = OONRetweetReplyFilter;
         let query = ScoredPostsQuery::default();
 
@@ -62,10 +62,36 @@ mod tests {
         let result = filter.filter(&query, candidates);
 
         let removed_ids: Vec<u64> = result.removed.iter().map(|c| c.tweet_id).collect();
-        assert_eq!(removed_ids, vec![1, 2, 8, 9]);
+        assert_eq!(removed_ids, vec![1, 2]);
 
         let kept_ids: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
-        assert_eq!(kept_ids, vec![3, 4, 5, 6, 7]);
+        assert_eq!(kept_ids, vec![3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[tokio::test]
+    async fn keeps_in_network_phoenix_reply_when_ancestors_empty() {
+        let filter = OONRetweetReplyFilter;
+        let query = ScoredPostsQuery::default();
+        let result = filter.filter(
+            &query,
+            vec![candidate(8, None, Some(800), vec![], Some(true))],
+        );
+        assert_eq!(result.kept.len(), 1);
+        assert_eq!(result.kept[0].tweet_id, 8);
+        assert!(result.removed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn still_drops_oon_reply_even_when_ancestors_present() {
+        let filter = OONRetweetReplyFilter;
+        let query = ScoredPostsQuery::default();
+        let result = filter.filter(
+            &query,
+            vec![candidate(2, None, Some(200), vec![200], Some(false))],
+        );
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0].tweet_id, 2);
+        assert!(result.kept.is_empty());
     }
 
     #[tokio::test]
@@ -104,6 +130,12 @@ mod tests {
                 ancestors: vec![300],
                 ..Default::default()
             },
+            PostCandidate {
+                tweet_id: 13,
+                author_id: 2,
+                in_reply_to_tweet_id: Some(400),
+                ..Default::default()
+            },
         ];
 
         let hydrator = InNetworkCandidateHydrator;
@@ -114,11 +146,12 @@ mod tests {
         assert_eq!(candidates[0].in_network, Some(false));
         assert_eq!(candidates[1].in_network, Some(false));
         assert_eq!(candidates[2].in_network, Some(true));
+        assert_eq!(candidates[3].in_network, Some(true));
 
         let result = OONRetweetReplyFilter.filter(&query, candidates);
         let removed_ids: Vec<u64> = result.removed.iter().map(|c| c.tweet_id).collect();
         assert_eq!(removed_ids, vec![10, 11]);
-        assert_eq!(result.kept.len(), 1);
-        assert_eq!(result.kept[0].tweet_id, 12);
+        let kept_ids: Vec<u64> = result.kept.iter().map(|c| c.tweet_id).collect();
+        assert_eq!(kept_ids, vec![12, 13]);
     }
 }


### PR DESCRIPTION
## Bug

Phoenix, MOE, Topics, and TweetMixer set `in_reply_to_tweet_id` and leave `ancestors` empty. Thunder copies the parent into `ancestors`.

`OONRetweetReplyFilter` dropped any reply with empty `ancestors`, including `in_network == Some(true)`. That ran in the pre-score filter chain, before Phoenix scoring and before VF.

A followee reply retrieved by Phoenix never reached For You. The same reply from Thunder survived.

This is not #179 (seen/served treating a reply as its parent). Not #180 (VF skipping Phoenix reply parents). #180 is post-selection ancillary VF. These cards died before that hydrator. Not #99 (self-reply chains). OON retweets and OON replies still drop.

## Five-line proof

- Entry: PhoenixSource / PhoenixMOESource / PhoenixTopicsSource / TweetMixerSource write `in_reply_to_tweet_id` and leave `ancestors` empty
- Sink: `OONRetweetReplyFilter` on `PhoenixCandidatePipeline` (pre-score)
- Break: `(is_reply && ancestors.is_empty())` fired after `InNetworkCandidateHydrator` stamped a followee reply `in_network = true`
- Viewer effect: a followee reply retrieved by Phoenix disappears from For You
- Twin: ThunderSource already pushes `in_reply_to` into `ancestors` and is kept; OON replies still drop

## Fix

Drop only OON retweets and OON replies. Empty ancestors is a producer gap, not an OON signal.

## Tests

- drops_oon_retweets_and_replies_only
- keeps_in_network_phoenix_reply_when_ancestors_empty
- still_drops_oon_reply_even_when_ancestors_present
- integrates_with_in_network_hydrator keeps followee Phoenix-shaped replies

`cargo test` cannot run. Public dump has no Home Mixer manifest. Standalone rustc model of the keep/drop predicate passed.

Fork PR: none (closed Pitchfork-and-Torch#65 as wrong tree)