### PR TITLE
Stop MoE corpus from keying the retweeter

### DIFF
--- a/home-mixer/scorers/author_cold_start.rs
+++ b/home-mixer/scorers/author_cold_start.rs
@@ -1,4 +1,4 @@
-use crate::models::candidate::PostCandidate;
+use crate::models::candidate::{CandidateHelpers, PostCandidate};
 use crate::models::query::ScoredPostsQuery;
 use crate::params::{
     AuthorIsControl, AuthorIsTreatment, ColdStartBetaAlpha0, ColdStartBetaBeta0,
@@ -182,8 +182,9 @@ fn author_corpus(
     candidates
         .iter()
         .map(|c| {
-            let is_treatment = author_rules.get(c.author_id, AuthorIsTreatment);
-            let is_control = author_rules.get(c.author_id, AuthorIsControl);
+            let author_id = c.get_original_author_id();
+            let is_treatment = author_rules.get(author_id, AuthorIsTreatment);
+            let is_control = author_rules.get(author_id, AuthorIsControl);
             match (is_treatment, is_control) {
                 (true, _) => AuthorCorpus::Treatment,
                 (false, true) => AuthorCorpus::Control,
@@ -500,6 +501,19 @@ rust_home_mixer:
         moe_candidate_with_favs(author_id, age, view_count_on_home, 0)
     }
 
+    fn moe_retweet(
+        retweeter_id: u64,
+        origin_author_id: u64,
+        age: Duration,
+        view_count_on_home: u64,
+    ) -> PostCandidate {
+        PostCandidate {
+            retweeted_user_id: Some(origin_author_id),
+            retweeted_tweet_id: Some(9_001),
+            ..moe_candidate(retweeter_id, age, view_count_on_home)
+        }
+    }
+
     fn moe_candidate_with_favs(
         author_id: u64,
         age: Duration,
@@ -643,6 +657,28 @@ rust_home_mixer:
         assert_eq!(result[0], 90.0);
         assert_eq!(result[1], 80.0);
         assert_eq!(result[2], 90.0);
+    }
+
+    #[test]
+    fn treatment_keeps_moe_retweet_of_treatment_origin() {
+        // Retweeter 99 is unbucketed; origin 1 is treatment. Corpus must
+        // key the origin or apply_moe_ranking_policy zeros the RT.
+        let author_cold_start = cold_start_with_arms(vec![1], vec![]);
+        let candidates = vec![moe_retweet(99, 1, minutes(10), 1000)];
+        let result =
+            author_cold_start.apply(&codivert_query(false, true), &candidates, &[80.0]);
+        assert_eq!(result, vec![80.0]);
+    }
+
+    #[test]
+    fn treatment_zeros_moe_retweet_of_control_origin() {
+        // Retweeter 1 is treatment; origin 3 is control. Keying the
+        // retweeter would leak control-author MoE into treatment.
+        let author_cold_start = cold_start_with_arms(vec![1], vec![3]);
+        let candidates = vec![moe_retweet(1, 3, minutes(10), 1000)];
+        let result =
+            author_cold_start.apply(&codivert_query(false, true), &candidates, &[80.0]);
+        assert_eq!(result, vec![0.0]);
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`AuthorColdStart::author_corpus` gated Phoenix MoE scores on wrapper `author_id`. Phoenix already keys the original author (`as_tweet_info` / `get_original_author_id`). A treatment-origin retweet by an unbucketed retweeter was zeroed. A control-origin retweet by a treatment retweeter leaked into treatment For You.

This is not #172 (RankingScorer author-diversity pool). This is not #31 / author-size IPS. This is not #125 (gizmoduck origin size/NSFW). Diversity stays the post-Phoenix repeat lever. Corpus membership is the MoE keep/zero gate.

## Five-line proof

1. Entry: Phoenix MoE retrieval stamps `ForYouPhoenixRetrievalMoe`; CoreData writes `retweeted_user_id` from TES `source_user_id`.
2. Sink: `author_corpus` -> `apply_moe_ranking_policy` -> `RankingScorer` / `VMRanker` -> `TopKScoreSelector`.
3. Break: corpus looked up `c.author_id` (retweeter). `get_original_author_id()` was unused.
4. Viewer: treatment For You lost MoE RTs of treatment authors via unbucketed retweeters, and kept MoE RTs of control authors via treatment retweeters.
5. Twin: `PostCandidate::as_tweet_info` already sends the original author to Phoenix. Cold-start boost already excludes RTs (`retweeted_tweet_id.is_none()`).

## Fix

Key `AuthorIsTreatment` / `AuthorIsControl` on `get_original_author_id()`. Originals and quotes unchanged.

## Tests

- `treatment_keeps_moe_retweet_of_treatment_origin` (fails on unmodified main)
- `treatment_zeros_moe_retweet_of_control_origin` (fails on unmodified main)
- Existing non-RT MoE / holdout / control tests unchanged

Standalone rustc model of old vs new corpus: 3/3 passed (2 fail on unmodified main).

cargo: cannot run. Public dump has no home-mixer Cargo.toml.

## Rejection table (this wave)

| Candidate | Why not |
|---|---|
| RankingScorer author diversity keying retweeter | #172 claimed |
| Author-size IPS | Forbidden |
| Gizmoduck origin size/NSFW | #125 claimed |
| Thunder undelete | #186 claimed |
| Thunder RT of tombstone / QuotedTweetDelete | #150 / #138 claimed |
| TimelineHome DMCA / geo media | #187 claimed |
| OON NSFW Phoenix skip | #185 claimed |
| Ads served bury organic | #184 claimed |
| Author / quote / RT handle mute-keyword | #182 / #140 / #164 claimed |
| mute_surfaces / mute_options on Gizmoduck | No live Entry: UserFeatures is Vec of strings only |
| WTF hide_recommendations | Sibling leftover; not this class |
| OON followee RT via stale in_network | Same class as #128 / #154 / #183 |
| TES/gizmoduck/VF fail-closed spray | Forbidden |
| SidTail / PopularTopics / BroadcastLiveness enable | Forbidden intern-enable |
