### PR TITLE
Stop VF from serving TES hateful-imagery and unknown takedowns

### DIFF
--- a/visibility-filtering/rules/context.rs
+++ b/visibility-filtering/rules/context.rs
@@ -257,6 +257,23 @@ impl TakedownPredicates<'_> {
         self.in_viewer_country(local_laws_takedown_country)
     }
 
+    /// TES global takedowns that are not country-coded and are not the DMCA
+    /// arm already consumed by `legal_in_viewer_country`.
+    #[inline]
+    pub fn is_global(&self) -> bool {
+        self.ctx
+            .candidate
+            .tweet_features
+            .takedown_reasons
+            .iter()
+            .any(|reason| {
+                matches!(
+                    reason,
+                    TakedownReason::HatefulImagery | TakedownReason::Unknown
+                )
+            })
+    }
+
     #[inline]
     fn in_viewer_country(&self, extractor: fn(&TakedownReason) -> Option<&str>) -> bool {
         let viewer_country = self.ctx.viewer.country_code.as_deref();

--- a/visibility-filtering/rules/golden_corpus.rs
+++ b/visibility-filtering/rules/golden_corpus.rs
@@ -621,6 +621,30 @@ fn tweet_shape_cases() -> Vec<Case> {
             expected_action: Allow,
             expected_decided_by: None,
         },
+        Case {
+            name: "hateful_imagery_takedown_drops_for_any_viewer",
+            level: TimelineHome,
+            viewer: viewer(VIEWER_ID),
+            candidate: takedown_candidate(TakedownReason::HatefulImagery),
+            expected_action: Drop(FilteredReason::UnspecifiedReason),
+            expected_decided_by: Some("DropGlobalTakendownPostRule"),
+        },
+        Case {
+            name: "unknown_takedown_drops_for_any_viewer",
+            level: TimelineHomeRecommendations,
+            viewer: viewer(VIEWER_ID),
+            candidate: takedown_candidate(TakedownReason::Unknown),
+            expected_action: Drop(FilteredReason::UnspecifiedReason),
+            expected_decided_by: Some("DropGlobalTakendownPostRule"),
+        },
+        Case {
+            name: "hateful_imagery_takedown_allows_author",
+            level: TimelineHome,
+            viewer: author_viewer(),
+            candidate: takedown_candidate(TakedownReason::HatefulImagery),
+            expected_action: Allow,
+            expected_decided_by: None,
+        },
     ]
 }
 

--- a/visibility-filtering/rules/registry.rs
+++ b/visibility-filtering/rules/registry.rs
@@ -226,6 +226,7 @@ rust_vf:
                 "DropStaleTweetsRule",
                 "DropLegalTakendownPostRule",
                 "DropLocalLawsTakendownPostRule",
+                "DropGlobalTakendownPostRule",
                 "SensitiveViewerLoggedOutDropRule",
                 "SensitiveViewerUnderageDropRule",
                 "SensitiveViewerNoStatedAgeDropRule",

--- a/visibility-filtering/rules/tweet_rules.rs
+++ b/visibility-filtering/rules/tweet_rules.rs
@@ -270,6 +270,13 @@ fn drop_local_laws_takendown_post(context: &RuleContext<'_>) -> VfAction {
     VfAction::Allow
 }
 
+fn drop_global_takendown_post(context: &RuleContext<'_>) -> VfAction {
+    if !context.viewer().is_author() && context.takedown().is_global() {
+        return VfAction::Drop(FilteredReason::UnspecifiedReason);
+    }
+    VfAction::Allow
+}
+
 fn drop_geo_restricted_media(context: &RuleContext<'_>) -> VfAction {
     if context.takedown().media_restricted_in_viewer_country() {
         VfAction::Drop(FilteredReason::UnspecifiedReason)
@@ -292,6 +299,10 @@ pub(super) const TES_HOME_DROPS: &[RuleSpec] = &[
     RuleSpec::Custom {
         name: "DropLocalLawsTakendownPostRule",
         evaluate: drop_local_laws_takendown_post,
+    },
+    RuleSpec::Custom {
+        name: "DropGlobalTakendownPostRule",
+        evaluate: drop_global_takendown_post,
     },
 ];
 
@@ -865,6 +876,9 @@ mod tests {
         ]);
         assert_allows(legal, &viewer_with_country("de"), &non_country);
         assert_allows(local, &viewer_with_country("de"), &non_country);
+        let global = tes_spec("DropGlobalTakendownPostRule");
+        assert_drops(global, &viewer_with_country("de"), &non_country, &reason);
+        assert_drops(global, &viewer(VIEWER_ID), &non_country, &reason);
     }
 
     #[test]
@@ -908,6 +922,18 @@ mod tests {
         let mut author_dmca = dmca.clone();
         author_dmca.author_id = VIEWER_ID;
         assert_allows(legal, &viewer(VIEWER_ID), &author_dmca);
+
+        let global = tes_spec("DropGlobalTakendownPostRule");
+        assert_allows(global, &viewer(VIEWER_ID), &dmca);
+        let hateful = takedown_candidate(vec![TakedownReason::HatefulImagery]);
+        assert_drops(global, &viewer_with_country("de"), &hateful, &reason);
+        assert_drops(global, &viewer(VIEWER_ID), &hateful, &reason);
+        assert_allows(legal, &viewer(VIEWER_ID), &hateful);
+        let unknown = takedown_candidate(vec![TakedownReason::Unknown]);
+        assert_drops(global, &viewer(VIEWER_ID), &unknown, &reason);
+        let mut author_hateful = hateful.clone();
+        author_hateful.author_id = VIEWER_ID;
+        assert_allows(global, &viewer(VIEWER_ID), &author_hateful);
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`legal_takedown_country` maps `TakedownReason::Dmca` to worldwide (`xy`) so `DropLegalTakendownPostRule` drops it on TimelineHome. `HatefulImagery` and `Unknown` fall through `_ => None`. No other wired rule reads them.

`takedown_country_axis` documents that the two geo rules Allow those reasons. Golden corpus has `dmca_takedown_drops_for_any_viewer` and no HatefulImagery / Unknown case.

This is not #187 (media-level `has_dmca_media` / geo lists). This is not #134 (TES RPC fail-closed). This is not #148 (withheld country list). This is not the DMCA arm of `DropLegalTakendownPostRule`.

## Proof

- Entry: `TesHydrator` writes `takedown_reasons` including `HatefulImagery` and `Unknown`.
- Sink: `TES_HOME_DROPS` / `RuleEngine` on TimelineHome and TimelineHomeRecommendations.
- Break: `legal_takedown_country` maps only `Dmca` to worldwide; `_ => None` for the other global variants.
- Viewer effect: a TES hateful-imagery or unknown-reason takedown is Allowed on Following and For You.
- Twin: `TakedownReason::Dmca => Some("xy")` already worldwide-drops via `DropLegalTakendownPostRule`.

## Fix

Add `TakedownPredicates::is_global` and wire `DropGlobalTakendownPostRule` into `TES_HOME_DROPS` after the geo takedown rows.

Drop `HatefulImagery` and `Unknown` for non-authors. Do not consume `Dmca` (stays on the legal rule) or country-coded reasons.

## Tests

- `takedown_country_axis` still Allows the two geo rules on HatefulImagery/Unknown; now Drops on the new rule
- `takedown_worldwide_axis` Drops HatefulImagery/Unknown; Allows Dmca on the new rule (fails if this twins the legal DMCA arm)
- `hateful_imagery_takedown_drops_for_any_viewer` (fails on unmodified main)
- `unknown_takedown_drops_for_any_viewer`
- `hateful_imagery_takedown_allows_author`
- `wired_rule_order_matches_pre_migration_sequence` lists the new row
- cargo: cannot run (public dump has no visibility-filtering Cargo.toml)
- Standalone decision-table harness (same match arms): 10/10 passed

Survey: #96-#193. Unclaimed. Not steward ads/Explore/soft-demotion/NaN. Not #187 media DMCA wiring.